### PR TITLE
Missing <publisher/>

### DIFF
--- a/Available_plugins.md
+++ b/Available_plugins.md
@@ -31,7 +31,7 @@ Replace attribute ```id``` with ```xml:id```.
 Add a new ```<div/>``` as parent for ```<list/>``` if the  ```<list/>``` element is a sibling of a ```<div/>``` element.
 
 ### missing-publisher
-Add an empty ```<publisher/>``` as first child to ```<publicationStmt/>``` if it does not contain any element from the *publicationStmtPart.agency* group (i.e. ```<publisher/>, <distributor/>, <authority/>```). N.B.: This plugin will only add an empty element, it does not guarantee that the order of the elements is valid if an element *publicationStmtPart.agency* group was already present.
+Add an empty ```<publisher/>``` as first child to ```<publicationStmt/>``` if it does not contain any element from the *publicationStmtPart.agency* group (i.e. ```<publisher/>, <distributor/>, <authority/>```). N.B.: This plugin will only add an empty element, it does not guarantee that the order of the elements is valid if an element of the *publicationStmtPart.agency* group was already present.
 
 ### notesstmt
 Remove ```type``` from ```<notesStmt/>```.

--- a/Available_plugins.md
+++ b/Available_plugins.md
@@ -30,6 +30,9 @@ Replace attribute ```id``` with ```xml:id```.
 ### list-div-sibling
 Add a new ```<div/>``` as parent for ```<list/>``` if the  ```<list/>``` element is a sibling of a ```<div/>``` element.
 
+### missing-publisher
+Add an empty ```<publisher/>``` as first child to ```<publicationStmt/>``` if it does not contain any element from the *publicationStmtPart.agency* group (i.e. ```<publisher/>, <distributor/>, <authority/>```). N.B.: This plugin will only add an empty element, it does not guarantee that the order of the elements is valid if an element *publicationStmtPart.agency* group was already present.
+
 ### notesstmt
 Remove ```type``` from ```<notesStmt/>```.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ list-div-sibling = "tei_transform.observer.list_as_div_sibling_observer:ListAsDi
 double-cell = "tei_transform.observer.double_cell_observer:DoubleCellObserver"
 hi-parent = "tei_transform.observer.hi_with_wrong_parent_observer:HiWithWrongParentObserver"
 byline-sibling = "tei_transform.observer.byline_sibling_observer:BylineSiblingObserver"
+missing-publisher = "tei_transform.observer.missing_publisher_observer:MissingPublisherObserver"
 
 # testing and dev tools
 [project.optional-dependencies]

--- a/tei_transform/observer/__init__.py
+++ b/tei_transform/observer/__init__.py
@@ -13,6 +13,7 @@ from tei_transform.observer.hi_with_wrong_parent_observer import (
 )
 from tei_transform.observer.id_attribute_observer import IdAttributeObserver
 from tei_transform.observer.list_as_div_sibling_observer import ListAsDivSiblingObserver
+from tei_transform.observer.missing_publisher_observer import MissingPublisherObserver
 from tei_transform.observer.notesstmt_observer import NotesStmtObserver
 from tei_transform.observer.p_as_div_sibling_observer import PAsDivSiblingObserver
 from tei_transform.observer.schemalocation_observer import SchemaLocationObserver

--- a/tei_transform/observer/missing_publisher_observer.py
+++ b/tei_transform/observer/missing_publisher_observer.py
@@ -1,0 +1,39 @@
+from lxml import etree
+
+from tei_transform.abstract_node_observer import AbstractNodeObserver
+
+
+class MissingPublisherObserver(AbstractNodeObserver):
+    """
+    Observer for <publicationStmt> elements that are missing <publisher/>.
+
+    Find empty <publicationStmt/> elements or <publicationStmt/> elements
+    that are missing an element from the publicationStmtPart.agency group
+    (i.e. <publisher/>, <authority/>, <distributor/>). If none of these
+    elements is present an empty <publisher/> element is inserted as first
+    child of the <publicationStmt/> element. N.B.: This will only check if
+    any of the required tags is present, not if they also appear as first
+    child of <publicationStmt/>.
+    """
+
+    # cf. https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-model.publicationStmtPart.agency.html
+    pub_stmt_agency_tags = {"publisher", "authority", "distributor"}
+
+    def observe(self, node: etree._Element) -> bool:
+        # empty <publicationStmt/>
+        if etree.QName(node).localname == "publicationStmt" and len(node) == 0:
+            return True
+        # check first child of <publicationStmt> if there are siblings
+        # from the publicationStmtPart.agency group
+        parent = node.getparent()
+        if parent is not None and etree.QName(parent).localname == "publicationStmt":
+            if parent.index(node) == 0 and not [
+                child
+                for child in parent
+                if etree.QName(child).localname in self.pub_stmt_agency_tags
+            ]:
+                return True
+        return False
+
+    def transform_node(self, node: etree._Element) -> None:
+        pass

--- a/tei_transform/observer/missing_publisher_observer.py
+++ b/tei_transform/observer/missing_publisher_observer.py
@@ -1,6 +1,7 @@
 from lxml import etree
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
+from tei_transform.element_transformation import create_new_element
 
 
 class MissingPublisherObserver(AbstractNodeObserver):
@@ -36,4 +37,9 @@ class MissingPublisherObserver(AbstractNodeObserver):
         return False
 
     def transform_node(self, node: etree._Element) -> None:
-        pass
+        if etree.QName(node).localname == "publicationStmt":
+            target = node
+        else:
+            target = node.getparent()
+        empty_publisher = create_new_element(node, "publisher")
+        target.insert(0, empty_publisher)

--- a/tests/test_missing_publisher_observer.py
+++ b/tests/test_missing_publisher_observer.py
@@ -102,3 +102,43 @@ class MissingPublisherObserverTester(unittest.TestCase):
             result = {self.observer.observe(node) for node in element.iter()}
             with self.subTest():
                 self.assertEqual(result, {False})
+
+    def test_publisher_inserted_on_empty_publicationStmt(self):
+        root = etree.XML("<fileDesc><publicationStmt/></fileDesc>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//publisher") is not None)
+
+    def test_publisher_inserted_on_publicationStmt_with_children(self):
+        root = etree.XML(
+            "<fileDesc><publicationStmt><pubPlace>city</pubPlace></publicationStmt></fileDesc>"
+        )
+        node = root.find(".//pubPlace")
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//publisher") is not None)
+
+    def test_publisher_inserted_on_empty_publicationStmt_with_namespace(self):
+        root = etree.XML(
+            "<TEI xmlns='ns'><teiHeader><fileDesc><publicationStmt/></fileDesc></teiHeader></TEI>"
+        )
+        node = root.find(".//{*}publicationStmt")
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//{*}publisher") is not None)
+
+    def test_publisher_inserted_on_complex_publicationStmt_with_namespace(self):
+        root = etree.XML(
+            """<TEI xmlns='ns'>
+                <teiHeader><fileDesc>
+                    <publicationStmt>
+                        <pubPlace/>
+                        <address>street</address>
+                        <date>today</date>
+                        <ab>some note</ab>
+                        <availability><license/></availability>
+                    </publicationStmt>
+                    </fileDesc></teiHeader>
+            </TEI>"""
+        )
+        node = root.find(".//{*}publicationStmt")
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//{*}publisher") is not None)

--- a/tests/test_missing_publisher_observer.py
+++ b/tests/test_missing_publisher_observer.py
@@ -1,0 +1,104 @@
+import unittest
+
+from lxml import etree
+
+from tei_transform.observer import MissingPublisherObserver
+
+
+class MissingPublisherObserverTester(unittest.TestCase):
+    def setUp(self):
+        self.observer = MissingPublisherObserver()
+
+    def test_observer_returns_true_for_matching_node(self):
+        node = etree.XML("<publicationStmt/>")
+        result = self.observer.observe(node)
+        self.assertTrue(result)
+
+    def test_observer_returns_false_for_non_matching_node(self):
+        node = etree.XML("<publicationStmt><publisher/></publicationStmt>")
+        result = self.observer.observe(node)
+        self.assertEqual(result, False)
+
+    def test_observer_identifies_matching_nodes(self):
+        elements = [
+            etree.XML("<publicationStmt><pubPlace/></publicationStmt>"),
+            etree.XML("<publicationStmt></publicationStmt>"),
+            etree.XML("<publicationStmt><idno>val</idno></publicationStmt>"),
+            etree.XML(
+                "<publicationStmt><pubPlace/><address>street</address></publicationStmt>"
+            ),
+            etree.XML("<publicationStmt><ab><publisher/></ab></publicationStmt>"),
+            etree.XML(
+                """<teiHeader><fileDesc>
+                <publicationStmt>
+                <date>today</date><address>street</address>street<pubPlace/>
+                </publicationStmt>
+                </fileDesc></teiHeader>"""
+            ),
+            etree.XML(
+                """<fileDesc>
+                <publicationStmt><date/><ab/><idno/><availability><license/></availability></publicationStmt>
+                </fileDesc>"""
+            ),
+            etree.XML(
+                "<fileDesc><publicationStmt><pubPlace>city</pubPlace></publicationStmt></fileDesc>"
+            ),
+            etree.XML("<teiHeader><fileDesc><publicationStmt/></fileDesc></teiHeader>"),
+            etree.XML(
+                """<TEI xmlns='ns'><teiHeader><fileDesc>
+                <publicationStmt><pubPlace>city</pubPlace></publicationStmt>
+                </fileDesc></teiHeader></TEI>"""
+            ),
+            etree.XML(
+                """<TEI xmlns='ns'><teiHeader><fileDesc>
+                        <publicationStmt>
+                        <pubPlace>city</pubPlace>
+                        <ab/><idno/>
+                        </publicationStmt>
+                        </fileDesc></teiHeader></TEI>"""
+            ),
+        ]
+        for element in elements:
+            result = [self.observer.observe(node) for node in element.iter()]
+            with self.subTest():
+                self.assertEqual(sum(result), 1)
+
+    def test_observer_ignores_non_matching_nodes(self):
+        elements = [
+            etree.XML("<publicationStmt><publisher>name</publisher></publicationStmt>"),
+            etree.XML("<publicationStmt><publisher/><pubPlace/></publicationStmt>"),
+            etree.XML("<publicationStmt><authority/></publicationStmt>"),
+            etree.XML("<publicationStmt><distributor/></publicationStmt>"),
+            etree.XML("<publicationStmt><publisher/></publicationStmt>"),
+            etree.XML(
+                "<publicationStmt><publisher><orgName/><country/><idno/></publisher><pubPlace/></publicationStmt>"
+            ),
+            etree.XML(
+                "<fileDesc><publicationStmt><authority/><date/></publicationStmt></fileDesc>"
+            ),
+            etree.XML(
+                "<fileDesc><publicationStmt><distributor/><availability/><idno/></publicationStmt></fileDesc>"
+            ),
+            etree.XML(
+                """<TEI xmlns='ns'><teiHeader>
+                <fileDesc><publicationStmt><publisher/><date/><idno/><pubPlace>city</pubPlace></publicationStmt>
+                </fileDesc></teiHeader></TEI>"""
+            ),
+            etree.XML(
+                """<TEI xmlns='ns'><teiHeader>
+                        <fileDesc><publicationStmt><authority><name>Name</name><note/></authority><date/><idno/><pubPlace>city</pubPlace></publicationStmt>
+                        </fileDesc></teiHeader></TEI>"""
+            ),
+            etree.XML(
+                """<TEI xmlns='ns'><teiHeader>
+                        <fileDesc><publicationStmt>
+                            <distributor>name<email>email@domain.org</email></distributor>
+                            <date/><idno/><pubPlace>city</pubPlace>
+                        </publicationStmt>
+                        </fileDesc></teiHeader></TEI>"""
+            ),
+        ]
+        for element in elements:
+            result = {self.observer.observe(node) for node in element.iter()}
+            with self.subTest():
+                self.assertEqual(result, {False})

--- a/tests/testdata/file_with_broken_publicationstmt.xml
+++ b/tests/testdata/file_with_broken_publicationstmt.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <funder>Funder</funder>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <extent>76</extent>
+      <publicationStmt>
+        <address id='val'>
+          <addrLine>address at city</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+      </publicationStmt>
+      <notesStmt>
+        <note type="source" anchored="true">CD</note>
+        <note type="type">
+          <idno type="date">2022-07-20</idno>
+        </note>
+      </notesStmt>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <publicationStmt>
+          </publicationStmt>
+          <head type='info'>some head</head>
+          <seriesStmt>
+            <title level="j">series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="series">Series</idno>
+              <idno type="volume">1</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <editionStmt>
+            <edition>edition</edition>
+          </editionStmt>
+          <publicationStmt>
+            <authority>Publisher</authority>
+            <pubPlace>Some city</pubPlace>
+            <date>2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">Series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="bibl">bibl info</idno>
+              <idno type="series">Series</idno>
+              <idno type="page_first">11</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <bibl></bibl>
+        </taxonomy>
+      </classDecl>
+      <projectDesc default="false">
+        <p>Project</p>
+      </projectDesc>
+      <samplingDecl default="false">
+        <p>description how the file was changed</p>
+      </samplingDecl>
+    </encodingDesc>
+    <profileDesc>
+      <textClass default="false">
+        <keywords scheme="#tax">
+          <term n="1" type="main">class</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change>0</change>
+      <change when="2022-07-21"><name>Other Person</name>Change description</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div>
+        <p>text</p>
+    </div>
+    </body>
+  </text>
+</TEI>

--- a/tests/testdata/file_with_missing_publisher.xml
+++ b/tests/testdata/file_with_missing_publisher.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <funder>Funder</funder>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <extent>76</extent>
+      <publicationStmt>
+        <address>
+          <addrLine>address at city</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+      </publicationStmt>
+      <notesStmt>
+        <note type="source" anchored="true">CD</note>
+        <note type="type">
+          <idno type="date">2022-07-20</idno>
+        </note>
+      </notesStmt>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date type="first">2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="series">Series</idno>
+              <idno type="volume">1</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <editionStmt>
+            <edition>edition</edition>
+          </editionStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date>2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">Series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="bibl">bibl info</idno>
+              <idno type="series">Series</idno>
+              <idno type="page_first">11</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <bibl></bibl>
+        </taxonomy>
+      </classDecl>
+      <projectDesc default="false">
+        <p>Project</p>
+      </projectDesc>
+      <samplingDecl default="false">
+        <p>description how the file was changed</p>
+      </samplingDecl>
+    </encodingDesc>
+    <profileDesc>
+      <textClass default="false">
+        <keywords scheme="#tax">
+          <term n="1" type="main">class</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change>0</change>
+      <change when="2022-07-21"><name>Other Person</name>Change description</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div>
+        <p>text</p>
+    </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
- Implement plugin for adding an empty `<publisher/>` element if `<publicationStmt/>` is missing an element of [model.publicationStmtPart.agency](https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-model.publicationStmtPart.agency.html)