### PR TITLE
Remove <relatedItem/> elements

### DIFF
--- a/Available_plugins.md
+++ b/Available_plugins.md
@@ -39,6 +39,9 @@ Add a new ```<div/>``` as parent for ```<p/>``` if the  ```<p/>``` element is a 
 ### p-head
 Replace tag ```<head/>``` elements that appear after ```<p/>``` with ```<ab/>``` and add ```type='head'``` attribute.
 
+### rel-item
+Remove ```<relatedItem/>``` elements that do not have children or do not have ```@target``` attribute. If the parent element would be empty after removal, it will also be removed.
+
 ### schemalocation
 Remove ```schemaLocation``` attribute from ```<TEI/>``` elements.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ list-div-sibling = "tei_transform.observer.list_as_div_sibling_observer:ListAsDi
 double-cell = "tei_transform.observer.double_cell_observer:DoubleCellObserver"
 hi-parent = "tei_transform.observer.hi_with_wrong_parent_observer:HiWithWrongParentObserver"
 byline-sibling = "tei_transform.observer.byline_sibling_observer:BylineSiblingObserver"
-
+rel-item = "tei_transform.observer.related_item_observer:RelatedItemObserver"
 # testing and dev tools
 [project.optional-dependencies]
 test = ["pytest>=7"]

--- a/tei_transform/observer/__init__.py
+++ b/tei_transform/observer/__init__.py
@@ -15,6 +15,7 @@ from tei_transform.observer.id_attribute_observer import IdAttributeObserver
 from tei_transform.observer.list_as_div_sibling_observer import ListAsDivSiblingObserver
 from tei_transform.observer.notesstmt_observer import NotesStmtObserver
 from tei_transform.observer.p_as_div_sibling_observer import PAsDivSiblingObserver
+from tei_transform.observer.related_item_observer import RelatedItemObserver
 from tei_transform.observer.schemalocation_observer import SchemaLocationObserver
 from tei_transform.observer.tail_text_observer import TailTextObserver
 from tei_transform.observer.tei_namespace_observer import TeiNamespaceObserver

--- a/tei_transform/observer/related_item_observer.py
+++ b/tei_transform/observer/related_item_observer.py
@@ -4,6 +4,16 @@ from tei_transform.abstract_node_observer import AbstractNodeObserver
 
 
 class RelatedItemObserver(AbstractNodeObserver):
+    """
+    Observer for <relatedItem/> elements without children.
+
+    Find <relatedItem/> elements that do not have any children
+    (but possibly contain text) and remove them. If the <relatedItem/>
+    element has the attribute '@target', it will not be removed.
+    If the parent element of <relatedItem/> would be empty after removal,
+    it will also be removed.
+    """
+
     def observe(self, node: etree._Element) -> bool:
         if etree.QName(node).localname == "relatedItem" and len(node) == 0:
             if "target" not in node.attrib:
@@ -11,4 +21,8 @@ class RelatedItemObserver(AbstractNodeObserver):
         return False
 
     def transform_node(self, node: etree._Element) -> None:
-        pass
+        parent = node.getparent()
+        parent.remove(node)
+        if len(parent) == 0:
+            grandparent = parent.getparent()
+            grandparent.remove(parent)

--- a/tei_transform/observer/related_item_observer.py
+++ b/tei_transform/observer/related_item_observer.py
@@ -1,0 +1,14 @@
+from lxml import etree
+
+from tei_transform.abstract_node_observer import AbstractNodeObserver
+
+
+class RelatedItemObserver(AbstractNodeObserver):
+    def observe(self, node: etree._Element) -> bool:
+        if etree.QName(node).localname == "relatedItem" and len(node) == 0:
+            if "target" not in node.attrib:
+                return True
+        return False
+
+    def transform_node(self, node: etree._Element) -> None:
+        pass

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -537,6 +537,14 @@ class IntegrationTester(unittest.TestCase):
         result = self.tei_validator.validate(output)
         self.assertTrue(result)
 
+    def test_related_item_removed(self):
+        file = os.path.join(self.data, "file_with_text_in_related_item.xml")
+        request = CliRequest(file, ["rel-item"])
+        self.use_case.process(request)
+        _, output = self.xml_writer.assertSingleDocumentWritten()
+        result = self.tei_validator.validate(output)
+        self.assertTrue(result)
+
     def file_invalid_because_classcode_missspelled(self, file):
         logs = self._get_validation_error_logs_for_file(file)
         expected_error_msg = "Did not expect element classcode there"

--- a/tests/test_related_item_observer.py
+++ b/tests/test_related_item_observer.py
@@ -51,19 +51,43 @@ class RelatedItemObserverTester(unittest.TestCase):
                     </biblFull></teiHeader><text/></TEI>"""
             ),
             etree.XML(
-                """<TEI xmlns='ns'><teiHeader><titleStmt/><biblFull><titleStmt/>
-                                <notesStmt><note/><relatedItem>text</relatedItem></notesStmt>
-                                </biblFull></teiHeader><text/></TEI>"""
+                """<TEI xmlns='ns'><teiHeader>
+                      <titleStmt/>
+                      <biblFull>
+                        <titleStmt/>
+                        <notesStmt>
+                            <note/>
+                            <relatedItem>text</relatedItem></notesStmt>
+                            </biblFull>
+                    </teiHeader><text/></TEI>"""
             ),
             etree.XML(
-                """<TEI><teiHeader><titleStmt/><biblFull><titleStmt/>
-                                            <notesStmt><note/><relatedItem type='orig'>text</relatedItem></notesStmt>
-                                            </biblFull></teiHeader><text/></TEI>"""
+                """<TEI><teiHeader>
+                      <titleStmt/>
+                        <biblFull>
+                          <titleStmt/>
+                          <notesStmt>
+                            <note/>
+                            <relatedItem type='orig'>text</relatedItem>
+                          </notesStmt>
+                        </biblFull>
+                    </teiHeader><text/></TEI>"""
             ),
             etree.XML(
-                """<TEI xmlns='ns'><teiHeader><titleStmt/><biblFull><titleStmt/>
-                                                        <notesStmt><note/><relatedItem type='type'>text</relatedItem></notesStmt>
-                                                        </biblFull></teiHeader><text/></TEI>"""
+                """
+            <TEI xmlns='ns'>
+              <teiHeader>
+                    <titleStmt/>
+                    <biblFull>
+                      <titleStmt/>
+                      <notesStmt
+                        <note/>
+                        <relatedItem type='type'>text</relatedItem>
+                      </notesStmt>
+                    </biblFull>
+                  </teiHeader>
+                  <text/>
+                </TEI>"""
             ),
         ]
         for element in elements:

--- a/tests/test_related_item_observer.py
+++ b/tests/test_related_item_observer.py
@@ -80,7 +80,7 @@ class RelatedItemObserverTester(unittest.TestCase):
                     <titleStmt/>
                     <biblFull>
                       <titleStmt/>
-                      <notesStmt
+                      <notesStmt>
                         <note/>
                         <relatedItem type='type'>text</relatedItem>
                       </notesStmt>

--- a/tests/test_related_item_observer.py
+++ b/tests/test_related_item_observer.py
@@ -121,3 +121,173 @@ class RelatedItemObserverTester(unittest.TestCase):
             result = {self.observer.observe(node) for node in element.iter()}
             with self.subTest():
                 self.assertEqual(result, {False})
+
+    def test_empty_element_removed(self):
+        root = etree.XML("<teiHeader><relatedItem/><bibl/></teiHeader>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertTrue(root.find("relatedItem") is None)
+
+    def test_element_with_text_removed(self):
+        root = etree.XML(
+            "<teiHeader><relatedItem>text</relatedItem><bibl/></teiHeader>"
+        )
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertTrue(root.find("relatedItem") is None)
+
+    def test_empty_element_with_attribute_removed(self):
+        root = etree.XML("<teiHeader><relatedItem type='val'/><bibl/></teiHeader>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertTrue(root.find("relatedItem") is None)
+
+    def test_element_with_text_and_attribute_removed(self):
+        root = etree.XML(
+            "<teiHeader><relatedItem type='val'>text</relatedItem><bibl/></teiHeader>"
+        )
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertTrue(root.find("relatedItem") is None)
+
+    def test_parent_removed_for_empty_related_item(self):
+        root = etree.XML("<teiHeader><notesStmt><relatedItem/></notesStmt></teiHeader>")
+        node = root.find(".//relatedItem")
+        self.observer.transform_node(node)
+        self.assertEqual(len(root), 0)
+
+    def test_parent_removed_for_related_item_with_text(self):
+        root = etree.XML(
+            "<teiHeader><notesStmt><relatedItem>text</relatedItem></notesStmt></teiHeader>"
+        )
+        node = root.find(".//relatedItem")
+        self.observer.transform_node(node)
+        self.assertEqual(len(root), 0)
+
+    def test_parent_removed_for_related_item_with_text_and_attribute(self):
+        root = etree.XML(
+            "<teiHeader><notesStmt><relatedItem xml:id='val'>text</relatedItem></notesStmt></teiHeader>"
+        )
+        node = root.find(".//relatedItem")
+        self.observer.transform_node(node)
+        self.assertEqual(len(root), 0)
+
+    def test_parent_removed_for_empty_related_item_with_attribute(self):
+        root = etree.XML(
+            "<teiHeader><notesStmt><relatedItem type='val'/></notesStmt></teiHeader>"
+        )
+        node = root.find(".//relatedItem")
+        self.observer.transform_node(node)
+        self.assertEqual(len(root), 0)
+
+    def test_parent_not_removed_if_other_siblings(self):
+        root = etree.XML(
+            """<teiHeader><notesStmt>
+                <bibl/>
+                <relatedItem xml:id='val'>text</relatedItem>
+                <note/>
+                </notesStmt></teiHeader>"""
+        )
+        node = root.find(".//relatedItem")
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//notesStmt") is not None)
+
+    def test_empty_element_removed_with_namespace(self):
+        root = etree.XML(
+            "<TEI xmlns='ns'><teiHeader><relatedItem/><bibl/></teiHeader></TEI>"
+        )
+        node = root.find(".//{*}relatedItem")
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//{*}relatedItem") is None)
+
+    def test_element_with_text_removed_with_namespace(self):
+        root = etree.XML(
+            "<TEI xmlns='ns'><teiHeader><relatedItem>text</relatedItem><bibl/></teiHeader></TEI>"
+        )
+        node = root.find(".//{*}relatedItem")
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//{*}relatedItem") is None)
+
+    def test_empty_element_with_attribute_removed_with_namespace(self):
+        root = etree.XML(
+            "<TEI xmlns='ns'><teiHeader><relatedItem attr='val'/><bibl/></teiHeader></TEI>"
+        )
+        node = root.find(".//{*}relatedItem")
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//{*}relatedItem") is None)
+
+    def test_element_with_text_and_attribute_removed_with_namespace(self):
+        root = etree.XML(
+            """<TEI xmlns='ns'><teiHeader>
+                <relatedItem attr='val'>text</relatedItem>
+                <bibl/>
+                </teiHeader></TEI>"""
+        )
+        node = root.find(".//{*}relatedItem")
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//{*}relatedItem") is None)
+
+    def test_parent_removed_for_empty_related_item_with_namespace(self):
+        root = etree.XML(
+            """<TEI xmlns='ns'><teiHeader>
+                  <notesStmt>
+                    <relatedItem/>
+                    <bibl/>
+                  </notesStmt>
+                </teiHeader></TEI>"""
+        )
+        node = root.find(".//{*}relatedItem")
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//{*}relatedItem") is None)
+
+    def test_parent_removed_for_related_item_with_text_with_namespace(self):
+        root = etree.XML(
+            """<TEI xmlns='ns'><teiHeader>
+                  <notesStmt>
+                    <relatedItem>text</relatedItem>
+                    <bibl/>
+                  </notesStmt>
+                </teiHeader></TEI>"""
+        )
+        node = root.find(".//{*}relatedItem")
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//{*}relatedItem") is None)
+
+    def test_parent_removed_for_rel_item_with_text_and_attribute_with_namespace(self):
+        root = etree.XML(
+            """<TEI xmlns='ns'><teiHeader>
+                  <notesStmt>
+                    <relatedItem attr='val'>text</relatedItem>
+                    <bibl/>
+                  </notesStmt>
+                </teiHeader></TEI>"""
+        )
+        node = root.find(".//{*}relatedItem")
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//{*}relatedItem") is None)
+
+    def test_parent_removed_for_empty_related_item_with_attribute_with_namespace(self):
+        root = etree.XML(
+            """<TEI xmlns='ns'><teiHeader>
+                          <notesStmt>
+                            <relatedItem attr='val'/>
+                            <bibl/>
+                          </notesStmt>
+                        </teiHeader></TEI>"""
+        )
+        node = root.find(".//{*}relatedItem")
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//{*}relatedItem") is None)
+
+    def test_parent_not_removed_if_other_siblings_with_namespace(self):
+        root = etree.XML(
+            """<TEI xmlns='ns'><teiHeader>
+                  <notesStmt>
+                    <relatedItem/>
+                    <bibl/>
+                  </notesStmt>
+                </teiHeader></TEI>"""
+        )
+        node = root.find(".//{*}relatedItem")
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//{*}notesStmt") is not None)

--- a/tests/test_related_item_observer.py
+++ b/tests/test_related_item_observer.py
@@ -1,0 +1,123 @@
+import unittest
+
+from lxml import etree
+
+from tei_transform.observer import RelatedItemObserver
+
+
+class RelatedItemObserverTester(unittest.TestCase):
+    def setUp(self):
+        self.observer = RelatedItemObserver()
+
+    def test_observer_returns_true_for_matching_element(self):
+        node = etree.XML("<relatedItem>text</relatedItem>")
+        result = self.observer.observe(node)
+        self.assertTrue(result)
+
+    def test_observer_returns_false_for_non_matching_element(self):
+        node = etree.XML("<relatedItem><bibl/></relatedItem>")
+        result = self.observer.observe(node)
+        self.assertEqual(result, False)
+
+    def test_observer_recognises_matching_elements(self):
+        elements = [
+            etree.XML("<relatedItem type='file'>path/to/file</relatedItem>"),
+            etree.XML("<relatedItem></relatedItem>"),
+            etree.XML("<relatedItem/>"),
+            etree.XML("<notesStmt><relatedItem>text</relatedItem></notesStmt>"),
+            etree.XML(
+                "<notesStmt><relatedItem type='file'>text</relatedItem></notesStmt>"
+            ),
+            etree.XML(
+                """<teiHeader>
+                      <biblFull>
+                        <notesStmt><relatedItem>text</relatedItem></notesStmt>
+                      </biblFull>
+                    </teiHeader>"""
+            ),
+            etree.XML(
+                """<teiHeader><biblFull><notesStmt>
+                    <relatedItem type='file'>text</relatedItem>
+                </notesStmt></biblFull></teiHeader>"""
+            ),
+            etree.XML(
+                """<teiHeader><biblFull><titleStmt/><notesStmt>
+                    <relatedItem>text</relatedItem>
+                </notesStmt></biblFull></teiHeader>"""
+            ),
+            etree.XML(
+                """<TEI><teiHeader><titleStmt/><biblFull><titleStmt/>
+                    <notesStmt><note/><relatedItem>text</relatedItem></notesStmt>
+                    </biblFull></teiHeader><text/></TEI>"""
+            ),
+            etree.XML(
+                """<TEI xmlns='ns'><teiHeader><titleStmt/><biblFull><titleStmt/>
+                                <notesStmt><note/><relatedItem>text</relatedItem></notesStmt>
+                                </biblFull></teiHeader><text/></TEI>"""
+            ),
+            etree.XML(
+                """<TEI><teiHeader><titleStmt/><biblFull><titleStmt/>
+                                            <notesStmt><note/><relatedItem type='orig'>text</relatedItem></notesStmt>
+                                            </biblFull></teiHeader><text/></TEI>"""
+            ),
+            etree.XML(
+                """<TEI xmlns='ns'><teiHeader><titleStmt/><biblFull><titleStmt/>
+                                                        <notesStmt><note/><relatedItem type='type'>text</relatedItem></notesStmt>
+                                                        </biblFull></teiHeader><text/></TEI>"""
+            ),
+        ]
+        for element in elements:
+            result = [self.observer.observe(node) for node in element.iter()]
+            with self.subTest():
+                self.assertEqual(sum(result), 1)
+
+    def test_observer_ignores_non_matching_elements(self):
+        elements = [
+            etree.XML("<relatedItem><el/></relatedItem>"),
+            etree.XML("<relatedItem target='other'/>"),
+            etree.XML("<relatedItem><biblFull/></relatedItem>"),
+            etree.XML(
+                "<relatedItem><biblFull><titleStmt><title/></titleStmt></biblFull></relatedItem>"
+            ),
+            etree.XML("<notesStmt><relatedItem><ptr/></relatedItem></notesStmt>"),
+            etree.XML("<biblFull><relatedItem target='preprint'/></biblFull>"),
+            etree.XML(
+                "<notesStmt><relatedItem type='other'><ptr/></relatedItem></notesStmt>"
+            ),
+            etree.XML(
+                "<teiHeader><notesStmt><relatedItem><bibl/></relatedItem></notesStmt></teiHeader>"
+            ),
+            etree.XML(
+                """<TEI>
+                <teiHeader><notesStmt>
+                    <relatedItem><bibl/></relatedItem>
+                </notesStmt></teiHeader>
+                </TEI>"""
+            ),
+            etree.XML(
+                """<TEI xmlns='ns'>
+                        <teiHeader><notesStmt>
+                        <relatedItem><bibl/></relatedItem>
+                        </notesStmt></teiHeader>
+                    </TEI>"""
+            ),
+            etree.XML(
+                """<TEI xmlns='ns'>
+                        <teiHeader><notesStmt>
+                            <relatedItem type='orig'><bibl/></relatedItem>
+                            </notesStmt></teiHeader>
+                        <text/>
+                    </TEI>"""
+            ),
+            etree.XML(
+                """<TEI xmlns='ns'>
+                        <teiHeader><notesStmt>
+                            <relatedItem target='other'/>
+                        </notesStmt></teiHeader>
+                    </TEI>"""
+            ),
+        ]
+        for element in elements:
+            result = {self.observer.observe(node) for node in element.iter()}
+            with self.subTest():
+                self.assertEqual(result, {False})

--- a/tests/testdata/file_with_text_in_related_item.xml
+++ b/tests/testdata/file_with_text_in_related_item.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <funder>Funder</funder>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <extent>76</extent>
+      <publicationStmt>
+        <publisher>Publisher</publisher>
+        <address>
+          <addrLine>address at city</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+        <authority>
+          <name/>
+        </authority>
+      </publicationStmt>
+      <notesStmt>
+        <note type="source" anchored="true">CD</note>
+        <note type="type">
+          <idno type="date">2022-07-20</idno>
+        </note>
+      </notesStmt>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date type="first">2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <relatedItem>
+              text
+            </relatedItem>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <editionStmt>
+            <edition>edition</edition>
+          </editionStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date>2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">Series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="bibl">bibl info</idno>
+              <idno type="series">Series</idno>
+              <idno type="page_first">11</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <bibl></bibl>
+        </taxonomy>
+      </classDecl>
+      <projectDesc default="false">
+        <p>Project</p>
+      </projectDesc>
+      <samplingDecl default="false">
+        <p>description how the file was changed</p>
+      </samplingDecl>
+    </encodingDesc>
+    <profileDesc>
+      <textClass default="false">
+        <keywords scheme="#tax">
+          <term n="1" type="main">class</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change>0</change>
+      <change when="2022-07-21"><name>Other Person</name>Change description</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <p>Actual text of the file</p>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
- Add plugin to remove  `<relatedItem/>` elements that don't contain children or `@target` attribute