### PR TITLE
Fix bug: p with children removed if not tail or text

### DIFF
--- a/observer_docs/list-div-sibling.md
+++ b/observer_docs/list-div-sibling.md
@@ -1,5 +1,5 @@
 ## list-div-sibling
-Find ```<list/>``` elements that are sibling of  ```<div/>``` elements and add a new ```<div/>``` wrapping the ```<list/>``` element.
+Find ```<list/>``` elements that are following sibling of  ```<div/>``` elements and add a new ```<div/>``` wrapping the ```<list/>``` element.
 
 ### Example
 Before transformation:

--- a/observer_docs/p-div-sibling.md
+++ b/observer_docs/p-div-sibling.md
@@ -1,11 +1,12 @@
 ## p-div-sibling
-Find ```<p/>``` elements that are sibling of  ```<div/>``` elements and add a new ```<div/>``` wrapping the ```<p/>``` element. Multiple consecutive ```<p/>``` elements following the same ```<div/>``` element will be grouped under the same new ```<div/>``` (instead of adding a ```<div/>``` for each ```<p/>```).
-Empty ```<p/>``` elements (i.e. not containing text, tail, or children) will be removed.
+Find ```<p/>``` elements that are following sibling of  ```<div/>``` elements and add a new ```<div/>``` wrapping the ```<p/>``` element. Multiple consecutive ```<p/>``` elements following the same ```<div/>``` element will be grouped under the same new ```<div/>``` (instead of adding a ```<div/>``` for each ```<p/>```).
+Empty ```<p/>``` elements (i.e. not containing text, tail, or children) will be removed.  `<p/>` elements preceding a `<div/>` element do not violate the TEI specifications and won't be wrapped by an additional `<div/>`.
 
 ### Example
 Before transformation:
 ```xml
 <body>
+  <p>text</p>
   <div>
     <p>text1</p>
   </div>
@@ -18,6 +19,7 @@ Before transformation:
 After transformation:
 ```xml
 <body>
+  <p>text</p>
   <div>
     <p>text1</p>
   </div>

--- a/tei_transform/observer/list_as_div_sibling_observer.py
+++ b/tei_transform/observer/list_as_div_sibling_observer.py
@@ -15,10 +15,7 @@ class ListAsDivSiblingObserver(AbstractNodeObserver):
 
     def observe(self, node: etree._Element) -> bool:
         if etree.QName(node).localname == "list":
-            if (
-                node.getparent() is not None
-                and list(node.getparent().iterchildren("{*}div")) != []
-            ):
+            if list(node.itersiblings("{*}div", preceding=True)) != []:
                 return True
         return False
 

--- a/tei_transform/observer/list_as_div_sibling_observer.py
+++ b/tei_transform/observer/list_as_div_sibling_observer.py
@@ -6,9 +6,9 @@ from tei_transform.element_transformation import create_new_element
 
 class ListAsDivSiblingObserver(AbstractNodeObserver):
     """
-    Observer for <list/> elements that are siblings of <div/>.
+    Observer for <list/> elements that are following siblings of <div/>.
 
-    Find <list/> elemnts that are siblings of <div/> and add a new
+    Find <list/> elements that are siblings of <div/> and add a new
     <div/> as parent of <list/>.
 
     """

--- a/tei_transform/observer/p_as_div_sibling_observer.py
+++ b/tei_transform/observer/p_as_div_sibling_observer.py
@@ -27,8 +27,10 @@ class PAsDivSiblingObserver(AbstractNodeObserver):
         return False
 
     def transform_node(self, node: etree._Element) -> None:
-        if (node.text is not None and node.text.strip()) or (
-            node.tail is not None and node.tail.strip()
+        if (
+            len(node) != 0
+            or (node.text is not None and node.text.strip())
+            or (node.tail is not None and node.tail.strip())
         ):
             sibling = node.getprevious()
             if sibling is not None:

--- a/tei_transform/observer/p_as_div_sibling_observer.py
+++ b/tei_transform/observer/p_as_div_sibling_observer.py
@@ -8,21 +8,19 @@ from tei_transform.element_transformation import create_new_element
 
 class PAsDivSiblingObserver(AbstractNodeObserver):
     """
-    Observer for <p/> elements that are siblings of <div/>.
+    Observer for <p/> elements that are following siblings of <div/>.
 
     Find <p/> elements that are direct siblings of <div/> elements
     and insert a new <div/> as parent of <p/>. Multiple <p/> after the
-    same <div/> will be united under the same new <div/> element.
+    same <div/> will be united under the same new <div/> element. If the
+    <p/> element is empty, it is removed.
     """
 
     _new_element: Optional[list] = None
 
     def observe(self, node: etree._Element) -> bool:
         if etree.QName(node).localname == "p":
-            if (
-                node.getparent() is not None
-                and list(node.getparent().iterchildren("{*}div")) != []
-            ):
+            if list(node.itersiblings("{*}div", preceding=True)) != []:
                 return True
         return False
 

--- a/tests/test_list_as_div_sibling_observer.py
+++ b/tests/test_list_as_div_sibling_observer.py
@@ -23,7 +23,7 @@ class ListAsDivSiblingObserverTester(unittest.TestCase):
         elements = [
             etree.XML("<div><div/><list/></div>"),
             etree.XML("<body><div/><list></list></body>"),
-            etree.XML("<body><list/><div/></body>"),
+            etree.XML("<body><list/><div/><list/></body>"),
             etree.XML("<body><div/><list><item/></list></body>"),
             etree.XML("<div><div/><div><div/></div><list/></div>"),
             etree.XML(
@@ -102,6 +102,7 @@ class ListAsDivSiblingObserverTester(unittest.TestCase):
     def test_observer_ignores_non_matching_elements(self):
         elements = [
             etree.XML("<div><list/></div>"),
+            etree.XML("<body><list/><div/></body>"),
             etree.XML("<div><div><list/></div></div>"),
             etree.XML(
                 "<div><list><item>some text</item><item>more text</item></list></div>"
@@ -314,67 +315,12 @@ class ListAsDivSiblingObserverTester(unittest.TestCase):
             ],
         )
 
-    def test_new_div_added_if_list_comes_before_div(self):
-        root = etree.XML(
-            """<TEI><teiHeader/>
-                <text><body><div>
-                <list><item>text</item><item/></list>
-                <div/>
-                </div></body></text></TEI>"""
-        )
-        for target_node in root.iter():
-            if self.observer.observe(target_node):
-                self.observer.transform_node(target_node)
-        result = [node.tag for node in root.iter()]
-        self.assertEqual(
-            result,
-            [
-                "TEI",
-                "teiHeader",
-                "text",
-                "body",
-                "div",
-                "div",
-                "list",
-                "item",
-                "item",
-                "div",
-            ],
-        )
-
-    def test_new_div_added_if_list_comes_before_div_with_namespace(self):
-        root = etree.XML(
-            """<TEI xmlns='namespace'><teiHeader/>
-                <text><body><div>
-                <list><item>text</item><item/></list>
-                <div/>
-                </div></body></text></TEI>"""
-        )
-        for target_node in root.iter():
-            if self.observer.observe(target_node):
-                self.observer.transform_node(target_node)
-        result = [etree.QName(node).localname for node in root.iter()]
-        self.assertEqual(
-            result,
-            [
-                "TEI",
-                "teiHeader",
-                "text",
-                "body",
-                "div",
-                "div",
-                "list",
-                "item",
-                "item",
-                "div",
-            ],
-        )
-
-    def test_new_div_added_for_list_if_older_sibling_not_div(self):
+    def test_new_div_added_for_list_if_older_sibling_not_only_div(self):
         root = etree.XML(
             """<TEI><teiHeader/>
                 <text><body><div>
                 <p/>
+                <div/>
                 <list><item>text</item><item/></list>
                 <div/>
                 </div></body></text></TEI>"""
@@ -392,6 +338,7 @@ class ListAsDivSiblingObserverTester(unittest.TestCase):
                 "body",
                 "div",
                 "p",
+                "div",
                 "div",
                 "list",
                 "item",

--- a/tests/test_p_as_div_sibling.py
+++ b/tests/test_p_as_div_sibling.py
@@ -23,7 +23,7 @@ class PAsDivSiblingObserverTester(unittest.TestCase):
         matching_elements = [
             etree.XML("<body><div/><p>text</p></body>"),
             etree.XML("<div><div/><p/></div>"),
-            etree.XML("<body><p/><div/></body>"),
+            etree.XML("<body><p/><div/><p/></body>"),
             etree.XML("<body><div><p>text></p></div><p>more text></p></body>"),
             etree.XML("<div><div/><div><div/></div><p/></div>"),
             etree.XML(
@@ -108,6 +108,7 @@ class PAsDivSiblingObserverTester(unittest.TestCase):
         elements = [
             etree.XML("<div></div>"),
             etree.XML("<div><div><p/></div></div>"),
+            etree.XML("<div><p/><div/></div>"),
             etree.XML("<div><p>some text</p><p>more text</p></div>"),
             etree.XML(
                 "<body><div><p>text></p></div><div><p>more text></p></div></body>"
@@ -172,12 +173,6 @@ class PAsDivSiblingObserverTester(unittest.TestCase):
         self.observer.transform_node(root[1])
         tags = [node.tag for node in root.iter()]
         self.assertTrue("p" in tags)
-
-    def test_empty_p_removed_with_div_sibling_after_p(self):
-        root = etree.XML("<body><p/><div/></body>")
-        self.observer.transform_node(root[0])
-        result = [node.tag for node in root.iter()]
-        self.assertEqual(result, ["body", "div"])
 
     def test_new_div_added_as_parent_of_p(self):
         root = etree.XML("<body><div/><p>text</p></body>")
@@ -272,91 +267,6 @@ class PAsDivSiblingObserverTester(unittest.TestCase):
         result = [etree.QName(node).localname for node in root.iter()]
         expected = ["TEI", "teiHeader", "text", "body", "div", "div", "div", "p"]
         self.assertEqual(result, expected)
-
-    def test_new_div_added_if_p_comes_before_div_sibling(self):
-        root = etree.XML(
-            """
-        <TEI>
-        <teiHeader/>
-        <text>
-        <body>
-        <p>text</p>
-        <div/>
-        </body>
-        </text>
-        </TEI>
-        """
-        )
-        node = root.find(".//{*}p")
-        self.observer.transform_node(node)
-        result = [node.tag for node in root.iter()]
-        expected = ["TEI", "teiHeader", "text", "body", "div", "p", "div"]
-        self.assertEqual(result, expected)
-
-    def test_new_div_added_if_p_comes_before_div_sibling_with_namespace(self):
-        root = etree.XML(
-            """
-        <TEI xmlns='namespace'>
-        <teiHeader/>
-        <text>
-        <body>
-        <p>text</p>
-        <div/>
-        </body>
-        </text>
-        </TEI>
-        """
-        )
-        node = root.find(".//{*}p")
-        self.observer.transform_node(node)
-        result = [etree.QName(node).localname for node in root.iter()]
-        expected = ["TEI", "teiHeader", "text", "body", "div", "p", "div"]
-        self.assertEqual(result, expected)
-
-    def test_new_div_added_if_div_after_p_with_other_element_before_p(self):
-        root = etree.XML(
-            """
-        <TEI xmlns='namespace'>
-        <teiHeader/>
-        <text>
-        <body>
-        <fw/>
-        <p>text</p>
-        <div/>
-        </body>
-        </text>
-        </TEI>
-        """
-        )
-        node = root.find(".//{*}p")
-        self.observer.transform_node(node)
-        result = [etree.QName(node).localname for node in root.iter()]
-        expected = ["TEI", "teiHeader", "text", "body", "fw", "div", "p", "div"]
-        self.assertEqual(result, expected)
-
-    def test_multiple_p_elements_added_to_same_div_if_div_sibling_comes_after(self):
-        root = etree.XML(
-            """
-            <TEI>
-            <teiHeader/>
-            <text>
-            <body>
-            <p>text</p>
-            <p>text</p>
-            <p>text</p>
-            <div/>
-            </body>
-            </text>
-            </TEI>
-            """
-        )
-        for node in root.iter():
-            if self.observer.observe(node):
-                self.observer.transform_node(node)
-        result = [node.tag for node in root.iter()]
-        self.assertEqual(
-            result, ["TEI", "teiHeader", "text", "body", "div", "p", "p", "p", "div"]
-        )
 
     def test_p_not_removed_if_child_but_not_text_or_tail(self):
         root = etree.XML(

--- a/tests/test_p_as_div_sibling.py
+++ b/tests/test_p_as_div_sibling.py
@@ -357,3 +357,36 @@ class PAsDivSiblingObserverTester(unittest.TestCase):
         self.assertEqual(
             result, ["TEI", "teiHeader", "text", "body", "div", "p", "p", "p", "div"]
         )
+
+    def test_p_not_removed_if_child_but_not_text_or_tail(self):
+        root = etree.XML(
+            """
+        <body>
+            <div>
+            <div/>
+            <p><hi>text</hi></p>
+            </div>
+        </body>
+        """
+        )
+        self.observer.transform_node(root.find(".//p"))
+        self.assertTrue(root.find(".//p") is not None)
+
+    def test_p_with_child_but_otherwise_empty_not_removed_with_namespace(self):
+        root = etree.XML(
+            """
+            <TEI xmlns="ns">
+                <teiHeader/>
+                <text>
+                    <body>
+                        <div>
+                        <div/>
+                        <p><hi>text</hi></p>
+                        </div>
+                    </body>
+                </text>
+            </TEI>
+            """
+        )
+        self.observer.transform_node(root.find(".//{*}p"))
+        self.assertTrue(root.find(".//{*}p") is not None)


### PR DESCRIPTION
- Fix removal of `<p/>` elements with children but without text or tail
- Change rules for element recognition of `p-div-sibling` and `list-div-sibling` (to allow elements before but not after `<div/>`)