### PR TITLE
Fix 'tail-text' plugin

### DIFF
--- a/Available_plugins.md
+++ b/Available_plugins.md
@@ -51,7 +51,7 @@ Remove ```<relatedItem/>``` elements that do not have children or do not have ``
 Remove ```@schemaLocation``` attribute from ```<TEI/>``` elements.
 
 ### [tail-text](observer_docs/tail-text.md)
-Remove text in tail of ```<p/>```, ```<ab/>``` and ```<fw/>``` if tail would be outside of a ```<p/>``` element. Add a new sibling ```<p/>``` that contains the former tail.
+Remove text in tail of ```<p/>```, ```<ab/>``` and ```<fw/>``` if parent is a ```<div/>```, `<body/>`, or `<floatingText/>`  element. Add a new sibling ```<p/>``` that contains the former tail.
 
 ### [teiheader](observer_docs/teiheader.md)
 Remove ```@type``` attribute from ```<teiHeader/>```.

--- a/observer_docs/tail-text.md
+++ b/observer_docs/tail-text.md
@@ -1,6 +1,6 @@
 ## tail-text
-Remove tail of elements with tag ```<p/>, <ab/>, or <fw/>``` if the tail is outside of a ```<p/>``` element (and counting thus, for example, as text in ```<div/>```). A new ```<p/>``` element is added containing the former tail as next sibling and the tail is removed from the original element. Only elements that are descendants of ```<text/>``` are considered (i.e. elements in the ```<teiHeader>``` are ignored.)
-
+Remove tail of elements with tag ```<p/>, <ab/>, or <fw/>``` if the parent of the element is  ```<div/>```, `<body/>`, or `<floatingText/>`. A new ```<p/>``` element is added containing the former tail as next sibling of the original element and the tail is removed from it.
+If the element has tag `fw/` and is a direct child of `<floatingText/>`, `fw`  will be used the tag of the newly added element instead of `p` (as `<p/>` cannot appear as child of `<floatingText/>`)
 ### Example
 Before transformation:
 ```xml

--- a/tei_transform/observer/tail_text_observer.py
+++ b/tei_transform/observer/tail_text_observer.py
@@ -9,9 +9,11 @@ class TailTextObserver(AbstractNodeObserver):
     Observer for elements with text in tail.
 
     Search for elements with tags <p>, <fw> or <ab> that
-    are descendants of <text> and contain text in their tail.
-    The text in the element tail will be removed and added to
-    a new sibling element with tag <p>.
+    are descendants of <div>, <body>, or <floatingText> and
+    contain text in their tail. The text in the element tail
+    will be removed and added to a new sibling element with
+    tag <p>. If the element has tag <fw> and is a direct descendant
+    of <floatingText>, the tag <fw> will be used instead of <p>.
     """
 
     def observe(self, node: etree._Element) -> bool:

--- a/tests/test_tail_text_observer.py
+++ b/tests/test_tail_text_observer.py
@@ -53,6 +53,17 @@ class TailTextObserverTester(unittest.TestCase):
             </text>
             """
             ),
+            etree.XML(
+                """
+                <text>
+                  <p>
+                    <floatingText>
+                      <fw>text</fw>tail
+                    </floatingText>
+                  </p>
+                </text>
+                """
+            ),
         ]
         for element in matching_elements:
             result = [self.observer.observe(node) for node in element.iter()]
@@ -221,3 +232,24 @@ class TailTextObserverTester(unittest.TestCase):
         node = root.find(".//{*}fw")
         self.observer.transform_node(node)
         self.assertEqual(node.getnext().text, "tail")
+
+    def test_tail_text_in_floating_text_not_added_under_p(self):
+        root = etree.XML(
+            """
+            <TEI>
+              <teiHeader/>
+              <text>
+                <body>
+                  <p>
+                    <floatingText>
+                      <fw>text</fw>tail>
+                    </floatingText>
+                  </p>
+                </body>
+              </text>
+            </TEI>
+            """
+        )
+        node = root.find(".//fw")
+        self.observer.transform_node(node)
+        self.assertEqual(len(root.findall(".//fw")), 2)

--- a/tests/test_tail_text_observer.py
+++ b/tests/test_tail_text_observer.py
@@ -37,6 +37,22 @@ class TailTextObserverTester(unittest.TestCase):
             <text><body><div><ab/>tail<p>text</p></div></body></text>
             </TEI>"""
             ),
+            etree.XML(
+                """
+            <text>
+                <div>
+                    <p>
+                        <floatingText>
+                          <body>
+                            <p/>
+                            <fw>text</fw>tail
+                          </body>
+                        </floatingText>
+                    </p>
+                </div>
+            </text>
+            """
+            ),
         ]
         for element in matching_elements:
             result = [self.observer.observe(node) for node in element.iter()]
@@ -110,6 +126,51 @@ class TailTextObserverTester(unittest.TestCase):
                 </TEI>"""
             ),
             etree.XML("<teiHeader><p/>tail</teiHeader>"),
+            etree.XML(
+                """
+                <text>
+                    <div>
+                      <p>
+                        <list>
+                          <item>
+                            <p>text</p>tail
+                          </item>
+                         </list>
+                      </p>
+                    </div>
+                </text>"""
+            ),
+            etree.XML(
+                """
+                <text>
+                  <div>
+                    <table>
+                      <row>
+                        <cell>
+                          <p>text</p>tail
+                        </cell>
+                      </row>
+                    </table>
+                  </div>
+                </text>
+                """
+            ),
+            etree.XML("<text><div><quote><p>text</p>tail</quote></div></text>"),
+            etree.XML(
+                """
+                <text>
+                  <div>
+                    <p>
+                      <list>
+                        <item>
+                          <fw>text</fw>tail
+                        </item>
+                      </list>
+                    </p>
+                  </div>
+                </text>
+                """
+            ),
         ]
         for element in elements:
             result = {self.observer.observe(node) for node in element.iter()}


### PR DESCRIPTION
- Fix unwanted behavior where valid tails would be removed, e.g. if contained in a `<floatingText/>`  or `<list/>` that is itself a descendant of `<p/>`.