### PR TITLE
'p-head' plugin: refine element identification

### DIFF
--- a/Available_plugins.md
+++ b/Available_plugins.md
@@ -42,7 +42,7 @@ Remove ```@type``` from ```<notesStmt/>```.
 Add a new ```<div/>``` as parent for ```<p/>``` if the  ```<p/>``` element is a sibling of a ```<div/>``` element.
 
 ### [p-head](observer_docs/p-head.md)
-Replace tag ```<head/>``` elements that appear after ```<p/>``` with ```<ab/>``` and add ```type='head'``` attribute.
+Replace tag ```<head/>``` elements that appear after  invalid elements (e.g ```<p/>```) with ```<ab/>``` and add ```type='head'``` attribute.
 
 ### [rel-item](observer_docs/rel-item.md)
 Remove ```<relatedItem/>``` elements that do not have children or do not have ```@target``` attribute. If the parent element would be empty after removal, it will also be removed.

--- a/observer_docs/p-head.md
+++ b/observer_docs/p-head.md
@@ -1,5 +1,5 @@
 ## p-head
-Replace ```<head/>``` tags that appear after ```<p/>``` with ```<ab/>``` and add ```@type="head"``` attribute.
+Replace ```<head/>``` tags that have older siblings that are not part of 'model.divWrapper' class or `<fw/>` with ```<ab/>``` and add ```@type="head"``` attribute. If the original `<head/>` element is empty (e.g. not containing children or non-whitespace text or tail), the element is removed.
 
 ### Example
 Before transformation:

--- a/tei_transform/observer/head_after_p_element_observer.py
+++ b/tei_transform/observer/head_after_p_element_observer.py
@@ -6,26 +6,42 @@ from tei_transform.element_transformation import change_element_tag
 
 class HeadAfterPElementObserver(AbstractNodeObserver):
     """
-    Observer for <head/> elements that appear after <p/> elements.
+    Observer for <head/> elements that have invalid elements as older siblings.
 
-    Find <head/> elements after <p/> and change their tag to <ab/>
-    and add the attribute [@type='head'].
+    Find <head/> elements after elements that are not <fw/> or part of
+    model.divWrapper and change their tag to <ab/> and add the attribute
+    [@type='head'].
     """
 
     def observe(self, node: etree._Element) -> bool:
-        qname = etree.QName(node.tag)
-        if qname.localname == "head":
-            older_sibling = node.getprevious()
-            if (
-                older_sibling is not None
-                and etree.QName(older_sibling.tag).localname == "p"
-            ):
+        allowed_before = [  # mainly elements from model.divWrapper
+            "fw",
+            "opener",
+            "argument",
+            "byline",
+            "dateline",
+            "docAuthor",
+            "docDate",
+            "epigraph",
+            "signed",
+            "meeting",
+            "salute",
+        ]
+        if etree.QName(node.tag).localname == "head":
+            if [
+                sibling
+                for sibling in node.itersiblings(preceding=True)
+                if etree.QName(sibling).localname not in allowed_before
+            ] != []:
                 return True
-            return False
         return False
 
     def transform_node(self, node: etree._Element) -> None:
-        if node.text or node.tail:
+        if (
+            len(node) != 0
+            or (node.text and node.text.strip())
+            or (node.tail and node.tail.strip())
+        ):
             change_element_tag(node, "ab")
             node.set("type", "head")
         else:

--- a/tests/test_head_after_p_element_observer.py
+++ b/tests/test_head_after_p_element_observer.py
@@ -37,6 +37,27 @@ class HeadAfterPElementObserverTester(unittest.TestCase):
              </text>
              </TEI>"""
             ),
+            etree.XML("<div><p/><fw>some other element</fw><head/></div>"),
+            etree.XML("<div><list/><head/></div>"),
+            etree.XML("<div><p/><figure/><head/></div>"),
+            etree.XML("<div><table/><head/></div>"),
+            etree.XML("<div><p/><docAuthor/><head/></div>"),
+            etree.XML(
+                """
+                <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+                  <teiHeader/>
+                  <text>
+                    <body>
+                      <div>
+                        <p/>
+                        <byline/>
+                        <head/>
+                      </div>
+                    </body>
+                  </text>
+                </TEI>
+                """
+            ),
         ]
         for element in matching_elements:
             result = [self.observer.observe(node) for node in element.iter()]
@@ -53,10 +74,35 @@ class HeadAfterPElementObserverTester(unittest.TestCase):
             etree.XML("<text><body><div><head/><p/></div></body></text>"),
             etree.XML(
                 """<TEI xmlns='http://www.tei-c.org/ns/1.0'>
-        <text>
-        <body><div><head>text</head></div><p/></body>
-        </text>
-        </TEI>"""
+            <text>
+            <body><div><head>text</head></div><p/></body>
+            </text>
+            </TEI>"""
+            ),
+            etree.XML("<div><fw/><head/></div>"),
+            etree.XML("<div><byline/><head/></div>"),
+            etree.XML("<div><dateline/><head>text</head><p/></div>"),
+            etree.XML("<div><opener/><head/></div>"),
+            etree.XML("<div><docAuthor/><head/></div>"),
+            etree.XML("<div><docDate/><head/></div>"),
+            etree.XML("<div><epigraph/><head/></div>"),
+            etree.XML("<div><signed/><head/></div>"),
+            etree.XML("<div><meeting/><head/></div>"),
+            etree.XML("<div><salute/><head/></div>"),
+            etree.XML(
+                """
+                <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+                  <teiHeader/>
+                  <text>
+                    <body>
+                      <div>
+                        <byline/>
+                        <head/>
+                        <p/>
+                      </div>
+                    </body>
+                  </text>
+                </TEI>"""
             ),
         ]
         for element in non_matching_elements:
@@ -141,3 +187,42 @@ class HeadAfterPElementObserverTester(unittest.TestCase):
                 self.observer.transform_node(node)
         result = [etree.QName(node.tag).localname for node in tree.iter()]
         self.assertEqual(result, ["TEI", "text", "body", "div", "p", "ab"])
+
+    def test_element_with_only_whitespace_in_tail_removed(self):
+        tree = etree.XML("<div><p/><head/>    </div>")
+        node = tree[1]
+        self.observer.transform_node(node)
+        self.assertEqual(len(tree), 1)
+
+    def test_element_with_only_whitespace_text_removed(self):
+        tree = etree.XML(
+            """
+            <div>
+                <p/>
+                <head>
+                </head>
+            </div>
+            """
+        )
+        node = tree[1]
+        self.observer.transform_node(node)
+        self.assertTrue(len(tree), 1)
+
+    def test_element_not_removed_if_children(self):
+        tree = etree.XML(
+            """
+            <TEI xmlns="ns">
+              <text>
+                <body>
+                  <div>
+                    <p/>
+                    <head><hi>text</hi></head>
+                  </div>
+                </body>
+              </text>
+            </TEI>
+            """
+        )
+        node = tree.find(".//{*}head")
+        self.observer.transform_node(node)
+        self.assertTrue(tree.find(".//{*}ab") is not None)

--- a/tests/test_head_after_p_element_observer.py
+++ b/tests/test_head_after_p_element_observer.py
@@ -32,10 +32,10 @@ class HeadAfterPElementObserverTester(unittest.TestCase):
             ),
             etree.XML(
                 """<TEI xmlns='http://www.tei-c.org/ns/1.0'>
-            # <text>
-            # <body><p/><head>text</head><p/></body>
-            # </text>
-            # </TEI>"""
+             <text>
+             <body><p/><head>text</head><p/></body>
+             </text>
+             </TEI>"""
             ),
         ]
         for element in matching_elements:


### PR DESCRIPTION
- Check all older siblings, not only the previous element and allow elements of 'model.divWrapper' class to appear before <head/>`