### PR TITLE
Handling of <change> and  <revisionDesc>

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For all available transformation plugins, see [Available Plugins](Available_plug
 
 If you want to add an entry in the <revisionDesc/> section of the transformed
 document, you can use the keyword argument **revision-config** and pass the name of
-the config file. This file should contain the following section:
+the config file. This file should contain the following section (The date entry is optional.):
 
 ```
 [revision]
@@ -79,7 +79,7 @@ person = Name of the responsible person
 reason = Reason how the file changed
 date = YYYY-MM-DD
 ```
-(The date entry is optional.)
+
 This will be rendered as a `<change/>` element and added as last child to `<revisionDesc/>`. If
  a `<revisionDesc/>` element was not part of the teiHeader before, it is added as last child
  of the `<teiHeader/>` element. The `<change/>` element will appear as follows in the document:

--- a/README.md
+++ b/README.md
@@ -74,10 +74,22 @@ the config file. This file should contain the following section:
 ```
 [revision]
 person = Name of the responsible person
-reason = Reason why the file changed
+reason = Reason how the file changed
 date = YYYY-MM-DD
 ```
 (The date entry is optional.)
+This will be rendered as a `<change/>` element and added as last child to `<revisionDesc/>`. If
+ a `<revisionDesc/>` element was not part of the teiHeader before, it is added as last child
+ of the `<teiHeader/>` element. The `<change/>` element will appear as follows in the document:
+
+```
+<change when="YYYY-MM-DD">
+  <name>Name of the responsible person</name>Reason how the file changed
+</change>
+```
+N.B.: Make sure that the `<revisionDesc/>` of the document(s) that are processed
+ contains only `<change/>` or `<listChange/>` elements as direct children. If the
+ original format uses '<list/>', the resulting document might not be valid.
 
 
 For all available transformation plugins, see [Available Plugins](Available_plugins.md) .

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This will be rendered as a `<change/>` element and added as last child to `<revi
 ```
 N.B.: Make sure that the `<revisionDesc/>` of the document(s) that are processed
  contains only `<change/>` or `<listChange/>` elements as direct children. If the
- original format uses '<list/>', the resulting document might not be valid.
+ original format uses `<list/>`, the resulting document might not be valid.
 
 
 For all available transformation plugins, see [Available Plugins](Available_plugins.md) .

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ options:
 
 The **file_or_dir** argument takes the path to the file you want to change.
 
+For all available transformation plugins, see [Available Plugins](Available_plugins.md) .
+
 If you want to add an entry in the <revisionDesc/> section of the transformed
 document, you can use the keyword argument **revision-config** and pass the name of
 the config file. This file should contain the following section:
@@ -91,8 +93,6 @@ N.B.: Make sure that the `<revisionDesc/>` of the document(s) that are processed
  contains only `<change/>` or `<listChange/>` elements as direct children. If the
  original format uses `<list/>`, the resulting document might not be valid.
 
-
-For all available transformation plugins, see [Available Plugins](Available_plugins.md) .
 
 ### Example
 

--- a/tei_transform/revision_desc_change.py
+++ b/tei_transform/revision_desc_change.py
@@ -21,8 +21,8 @@ def construct_change_from_config_file(file: str) -> Optional[RevisionDescChange]
     where the information for the change is stored.
     Return a RevisionDescChange with the gathered information.
     In the config file, the [revision] section should specify a 'person'
-    responsible for the change and a 'reason' why the file was changed. An
-    optional 'date' can also be named. If 'date' is missing, the current
+    responsible for the change and a 'reason' how the file was changed. An
+    optional 'date' can also be indicated. If 'date' is missing, the current
     date will be used.
     """
     config = configparser.ConfigParser()
@@ -41,7 +41,5 @@ def construct_change_from_config_file(file: str) -> Optional[RevisionDescChange]
         date = datetime.date.fromisoformat(date_entry)
     except ValueError:
         logger.info("No valid date specified, using today's date.")
-        date = None
-    if date is None:
         date = datetime.date.today()
     return RevisionDescChange(person=person, date=date.isoformat(), reason=reason)

--- a/tei_transform/tei_transformer.py
+++ b/tei_transform/tei_transformer.py
@@ -89,13 +89,10 @@ class TeiTransformer:
     ) -> None:
         revision_node = etree.Element(etree.QName(ns_prefix, "revisionDesc"))
         revision_node.append(new_change)
-        # check where to insert revisionDesc
-        for node in ["profileDesc", "fileDesc", "encodingDesc"]:
-            prev_sibling = tree.find(f".//{{*}}{node}")
-            if prev_sibling is not None:
-                prev_sibling.addnext(revision_node)
-                break
-        return None
+        # add revisionDesc as last child of teiHeader if not present
+        teiheader = tree.find(".//{*}teiHeader")
+        if teiheader is not None:
+            teiheader.append(revision_node)
 
     def _transform_subtree_of_node(self, node: etree._Element) -> None:
         for subnode in node.iter():

--- a/tei_transform/tei_transformer.py
+++ b/tei_transform/tei_transformer.py
@@ -68,11 +68,14 @@ class TeiTransformer:
         new_change = etree.Element(
             etree.QName(ns_prefix, "change"), {"when": change.date}
         )
-        new_change.text = change.reason
         for person_name in change.person:
             name_node = etree.Element(etree.QName(ns_prefix, "name"))
             name_node.text = person_name
             new_change.append(name_node)
+        if len(new_change) > 0:
+            new_change[-1].tail = change.reason
+        else:
+            new_change.text = change.reason
 
         revision_node = tree.find(".//{*}revisionDesc")
         if revision_node is None:

--- a/tei_transform/tei_transformer.py
+++ b/tei_transform/tei_transformer.py
@@ -81,11 +81,7 @@ class TeiTransformer:
         if revision_node is None:
             self._add_revision_desc_to_tei_header(tree, new_change, ns_prefix)
         else:
-            first_child_tag = etree.QName(revision_node[0].tag).localname
-            if first_child_tag == "change":
-                revision_node.append(new_change)
-            elif first_child_tag == "listChange":
-                revision_node[0].append(new_change)
+            revision_node.append(new_change)
         return tree
 
     def _add_revision_desc_to_tei_header(

--- a/tests/test_tei_transformer.py
+++ b/tests/test_tei_transformer.py
@@ -403,6 +403,40 @@ class TeiTransformerTester(unittest.TestCase):
         ).getroot()
         tree = self.transformer.add_change_to_revision_desc(xml, change)
         revision_desc = tree.find(".//revisionDesc")
+        last_change = revision_desc[-1][-1]
+        self.assertEqual(last_change.tail, "Change reason")
+
+    def test_change_reason_set_as_tail_of_last_person_name(self):
+        change = RevisionDescChange(
+            person=["Vorname Nachname", "Zweite Person"],
+            date="2022-07-25",
+            reason="Change reason",
+        )
+        self.transformer.set_list_of_observers([FakeObserver()])
+        xml = etree.parse(
+            io.BytesIO(
+                b"<teiHeader><revisionDesc><change>0</change></revisionDesc></teiHeader>"
+            )
+        ).getroot()
+        tree = self.transformer.add_change_to_revision_desc(xml, change)
+        revision_desc = tree.find(".//revisionDesc")
+        last_change = revision_desc[-1][-1]
+        self.assertEqual(last_change.tail, "Change reason")
+
+    def test_change_reason_set_as_text_of_change_element_if_name_missing(self):
+        change = RevisionDescChange(
+            person=[],
+            date="2022-07-25",
+            reason="Change reason",
+        )
+        self.transformer.set_list_of_observers([FakeObserver()])
+        xml = etree.parse(
+            io.BytesIO(
+                b"<teiHeader><revisionDesc><change>0</change></revisionDesc></teiHeader>"
+            )
+        ).getroot()
+        tree = self.transformer.add_change_to_revision_desc(xml, change)
+        revision_desc = tree.find(".//revisionDesc")
         last_change = revision_desc[-1]
         self.assertEqual(last_change.text, "Change reason")
 

--- a/tests/test_tei_transformer.py
+++ b/tests/test_tei_transformer.py
@@ -306,13 +306,21 @@ class TeiTransformerTester(unittest.TestCase):
         )
         self.transformer.set_list_of_observers([FakeObserver()])
         xml = etree.parse(
-            io.BytesIO(b"<teiHeader><fileDesc/><profileDesc/></teiHeader>")
+            io.BytesIO(b"<TEI><teiHeader><fileDesc/><profileDesc/></teiHeader></TEI>")
         ).getroot()
         tree = self.transformer.add_change_to_revision_desc(xml, change)
         result = [node.tag for node in tree.iter()]
         self.assertEqual(
             result,
-            ["teiHeader", "fileDesc", "profileDesc", "revisionDesc", "change", "name"],
+            [
+                "TEI",
+                "teiHeader",
+                "fileDesc",
+                "profileDesc",
+                "revisionDesc",
+                "change",
+                "name",
+            ],
         )
 
     def test_namespace_added_to_new_revision_desc(self):

--- a/tests/test_tei_transformer.py
+++ b/tests/test_tei_transformer.py
@@ -295,11 +295,8 @@ class TeiTransformerTester(unittest.TestCase):
             )
         ).getroot()
         tree = self.transformer.add_change_to_revision_desc(xml, change)
-        result = [node.tag for node in tree.iter()]
-        self.assertEqual(
-            result,
-            ["teiHeader", "revisionDesc", "listChange", "change", "change", "name"],
-        )
+        result = [node.tag for node in tree.find(".//revisionDesc")]
+        self.assertEqual(result, ["listChange", "change"])
 
     def test_revision_desc_added_if_not_present_before(self):
         change = RevisionDescChange(

--- a/tests/test_use_case_impl.py
+++ b/tests/test_use_case_impl.py
@@ -183,23 +183,27 @@ class UseCaseTester(unittest.TestCase):
         revision_node = result_tree.find(".//{*}revisionDesc")
         last_change = revision_node[-1]
         expected = etree.Element("{http://www.tei-c.org/ns/1.0}change")
-        expected.text = "The reason why the file was changed"
         expected_name = etree.Element("{http://www.tei-c.org/ns/1.0}name")
+        expected_name.tail = "The reason why the file was changed"
         expected_name.text = "Some Name"
         expected.set("when", "2022-05-23")
         expected.append(expected_name)
         self.assertEqual(
             (
                 last_change.tag,
-                last_change.text,
                 last_change.attrib,
-                [(child.tag, child.text) for child in last_change.getchildren()],
+                [
+                    (child.tag, child.text, child.tail)
+                    for child in last_change.getchildren()
+                ],
             ),
             (
                 expected.tag,
-                expected.text,
                 expected.attrib,
-                [(child.tag, child.text) for child in expected.getchildren()],
+                [
+                    (child.tag, child.text, child.tail)
+                    for child in expected.getchildren()
+                ],
             ),
         )
 


### PR DESCRIPTION
- Change format of `<change/>` element (change description added as tail of name if present)
- Avoid appending to `<listChange/>` if present
- Add `<revisionDesc/>` as last child to `<teiHeader/>` if not already present