### PR TITLE
Fix addnext

### DIFF
--- a/tei_transform/observer/list_as_div_sibling_observer.py
+++ b/tei_transform/observer/list_as_div_sibling_observer.py
@@ -20,8 +20,8 @@ class ListAsDivSiblingObserver(AbstractNodeObserver):
         return False
 
     def transform_node(self, node: etree._Element) -> None:
-        sibling = node.getprevious()
+        parent = node.getparent()
         new_element = create_new_element(node, "div")
-        if sibling is not None:
-            sibling.addnext(new_element)
+        if parent is not None:
+            parent.insert(parent.index(node), new_element)
             new_element.append(node)

--- a/tei_transform/observer/p_as_div_sibling_observer.py
+++ b/tei_transform/observer/p_as_div_sibling_observer.py
@@ -36,7 +36,8 @@ class PAsDivSiblingObserver(AbstractNodeObserver):
                     self._new_element.append(node)
                 else:
                     new_element = create_new_element(node, "div")
-                    sibling.addnext(new_element)
+                    parent = sibling.getparent()
+                    parent.insert(parent.index(node), new_element)
                     self._new_element = new_element
                     new_element.append(node)
         else:

--- a/tests/test_list_as_div_sibling_observer.py
+++ b/tests/test_list_as_div_sibling_observer.py
@@ -346,3 +346,12 @@ class ListAsDivSiblingObserverTester(unittest.TestCase):
                 "div",
             ],
         )
+
+    def test_new_div_inserted_at_correct_index(self):
+        root = etree.XML("<body><div><div/><list/></div></body>")
+        target_node = root.find(".//list")
+        expected = target_node.getparent().index(target_node)
+        self.observer.transform_node(target_node)
+        new_div = root.find(".//div/list").getparent()
+        result = new_div.getparent().index(new_div)
+        self.assertEqual(result, expected)

--- a/tests/test_p_as_div_sibling.py
+++ b/tests/test_p_as_div_sibling.py
@@ -300,3 +300,24 @@ class PAsDivSiblingObserverTester(unittest.TestCase):
         )
         self.observer.transform_node(root.find(".//{*}p"))
         self.assertTrue(root.find(".//{*}p") is not None)
+
+    def test_tail_of_sibling_not_transfered_to_new_div(self):
+        root = etree.XML(
+            """
+            <TEI xmlns='ns'>
+              <teiHeader/>
+              <text>
+                <body>
+                  <div/>
+                  <div/>tail
+                  <p>text</p>
+                </body>
+              </text>
+            </TEI>
+            """
+        )
+        node = root.find(".//{*}p")
+        self.observer.transform_node(node)
+        parent = node.getparent()
+        self.assertEqual(parent.tail, None)
+        self.assertEqual(parent.getprevious().tail.strip(), "tail")

--- a/tests/test_tail_text_observer.py
+++ b/tests/test_tail_text_observer.py
@@ -253,3 +253,13 @@ class TailTextObserverTester(unittest.TestCase):
         node = root.find(".//fw")
         self.observer.transform_node(node)
         self.assertEqual(len(root.findall(".//fw")), 2)
+
+    def test_tail_from_original_element_not_transfered_to_new_sibling(self):
+        root = etree.XML(
+            """<TEI xmlns="http://www.tei-c.org/ns/1.0">
+                    <text><div><fw/>tail</div></text>
+                </TEI>"""
+        )
+        node = root.find(".//{*}fw")
+        self.observer.transform_node(node)
+        self.assertEqual(node.getnext().tail, None)


### PR DESCRIPTION
`elem.addnext(new_sibling)` (from `lxml.etree`) transfers the tail of `elem` to `new_sibling`. This PR fixes unwanted transfer of tails by replacing calls of `addnext` with `insert` where such a transfer might occur. 