### PR TITLE
Handle Lonely <row> elements

### DIFF
--- a/Available_plugins.md
+++ b/Available_plugins.md
@@ -32,6 +32,9 @@ Replace attribute ```@id``` with ```@xml:id```.
 ### [list-div-sibling](observer_docs/list-div-sibling.md)
 Add a new ```<div/>``` as parent for ```<list/>``` if the  ```<list/>``` element is a sibling of a ```<div/>``` element.
 
+### [lonely-row](observer_docs/lonely-row.md)
+Wrap `<row/>` elements that are outside a `<table/>` element with `<table/>`.
+
 ### [missing-publisher](observer_docs/missing-publisher.md)
 Add an empty ```<publisher/>``` as first child to ```<publicationStmt/>``` if it does not contain any element from the *publicationStmtPart.agency* group (i.e. ```<publisher/>, <distributor/>, <authority/>```). N.B.: This plugin will only add an empty element, it does not guarantee that the order of the elements is valid if an element of the *publicationStmtPart.agency* group was already present.
 

--- a/observer_docs/lonely-row.md
+++ b/observer_docs/lonely-row.md
@@ -1,0 +1,46 @@
+## lonely-row
+Find `<row/>` elements that are not a direct descendant of `<table/>` and add a new `<table/>` element as parent. Adjacent `<row/>` elements will be added to the same `<table/>` element. If the `<row/>` element is empty (i.e. doesn't have descendants, text, or tail), it is removed instead of wrapping it in a `<table/>` element.
+If the `<row/>` element has a tail, the tail is moved to the `<table/>` parent element or, if already existing, concatenated with the tail of the parent.
+
+
+### Example
+Before transformation:
+```xml
+<div>
+  <p>
+    <row>
+      <cell>text</cell>
+    </row>
+    <row>
+      <cell>text2</cell>
+      <cell>text3</cell>
+    </row>tail
+  </p>
+  <row/>
+  <row>
+    <cell>new table</cell>
+  </row>
+</div>
+```
+
+After transformation:
+```xml
+<div>
+  <p>
+    <table>
+      <row>
+        <cell>text</cell>
+      </row>
+      <row>
+        <cell>text2</cell>
+        <cell>text3</cell>
+      </row>
+    </table>tail
+  </p>
+  <table>
+    <row>
+      <cell>new table</cell>
+    </row>
+  </table>
+</div>
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ head-type = "tei_transform.observer.head_with_type_attr_observer:HeadWithTypeAtt
 hi-parent = "tei_transform.observer.hi_with_wrong_parent_observer:HiWithWrongParentObserver"
 id-attribute = "tei_transform.observer.id_attribute_observer:IdAttributeObserver"
 list-div-sibling = "tei_transform.observer.list_as_div_sibling_observer:ListAsDivSiblingObserver"
+lonely-row = "tei_transform.observer.lonely_row_observer:LonelyRowObserver"
 missing-publisher = "tei_transform.observer.missing_publisher_observer:MissingPublisherObserver"
 notesstmt = "tei_transform.observer.notesstmt_observer:NotesStmtObserver"
 p-div-sibling = "tei_transform.observer.p_as_div_sibling_observer:PAsDivSiblingObserver"

--- a/tei_transform/observer/__init__.py
+++ b/tei_transform/observer/__init__.py
@@ -13,6 +13,7 @@ from tei_transform.observer.hi_with_wrong_parent_observer import (
 )
 from tei_transform.observer.id_attribute_observer import IdAttributeObserver
 from tei_transform.observer.list_as_div_sibling_observer import ListAsDivSiblingObserver
+from tei_transform.observer.lonely_row_observer import LonelyRowObserver
 from tei_transform.observer.missing_publisher_observer import MissingPublisherObserver
 from tei_transform.observer.notesstmt_observer import NotesStmtObserver
 from tei_transform.observer.p_as_div_sibling_observer import PAsDivSiblingObserver

--- a/tei_transform/observer/lonely_row_observer.py
+++ b/tei_transform/observer/lonely_row_observer.py
@@ -1,0 +1,14 @@
+from lxml import etree
+from tei_transform.abstract_node_observer import AbstractNodeObserver
+
+
+class LonelyRowObserver(AbstractNodeObserver):
+    def observe(self, node: etree._Element) -> bool:
+        if etree.QName(node).localname == "row":
+            parent = node.getparent()
+            if parent is not None and etree.QName(parent).localname != "table":
+                return True
+        return False
+
+    def transform_node(self, node: etree._Element) -> None:
+        pass

--- a/tei_transform/observer/lonely_row_observer.py
+++ b/tei_transform/observer/lonely_row_observer.py
@@ -1,8 +1,19 @@
+from typing import Optional
+
 from lxml import etree
+
 from tei_transform.abstract_node_observer import AbstractNodeObserver
+from tei_transform.element_transformation import create_new_element
 
 
 class LonelyRowObserver(AbstractNodeObserver):
+    """
+    Observer for <row/> elements outside <table/>.
+
+    """
+
+    _new_table: Optional[etree._Element] = None
+
     def observe(self, node: etree._Element) -> bool:
         if etree.QName(node).localname == "row":
             parent = node.getparent()
@@ -11,4 +22,23 @@ class LonelyRowObserver(AbstractNodeObserver):
         return False
 
     def transform_node(self, node: etree._Element) -> None:
-        pass
+        parent = node.getparent()
+        if (
+            len(node) == 0
+            and (node.text is None or not node.text.strip())
+            and (node.tail is None or not node.tail.strip())
+        ):
+            parent.remove(node)
+            return
+        prev_sibling = node.getprevious()
+        if prev_sibling is None or prev_sibling != self._new_table:
+            new_table = create_new_element(node, "table")
+            parent.insert(parent.index(node), new_table)
+            self._new_table = new_table
+        self._new_table.append(node)
+        if node.tail is not None and node.tail.strip():
+            if self._new_table.tail is None:
+                self._new_table.tail = node.tail.strip()
+            else:
+                self._new_table.tail += f" {node.tail.strip()}"
+            node.tail = None

--- a/tei_transform/observer/lonely_row_observer.py
+++ b/tei_transform/observer/lonely_row_observer.py
@@ -10,6 +10,13 @@ class LonelyRowObserver(AbstractNodeObserver):
     """
     Observer for <row/> elements outside <table/>.
 
+    Find <row/> elements that are outside a <table/> element
+    and add a new <table/> as parent. Adjacent <row/> elements
+    will be added to the same <table/> element. Empty <row/>
+    (no children, text, or tail) elements are removed.
+    The tail on the <row/> element is added to the new <table/>
+    parent (N.B.: This might not be valid TEI if the former
+    parent was, for instance, a <div/> element).
     """
 
     _new_table: Optional[etree._Element] = None

--- a/tests/test_byline_sibling_observer.py
+++ b/tests/test_byline_sibling_observer.py
@@ -104,7 +104,7 @@ class BylineSiblingObserverTester(unittest.TestCase):
         result = [node.tag for node in root.find("div").iter()]
         self.assertEqual(result, ["div", "p", "byline"])
 
-    def test_observer_action_performed_on_simple_byline_wiht_sibling(self):
+    def test_observer_action_performed_on_simple_byline_with_sibling(self):
         root = etree.XML("<div><p>text</p><byline>byline</byline><p>text2</p></div>")
         node = root.find(".//byline").getnext()
         self.observer.transform_node(node)

--- a/tests/test_lonely_row_observer.py
+++ b/tests/test_lonely_row_observer.py
@@ -1,0 +1,239 @@
+import unittest
+
+from lxml import etree
+
+from tei_transform.observer import LonelyRowObserver
+
+
+class LonelyRowObserverTester(unittest.TestCase):
+    def setUp(self):
+        self.observer = LonelyRowObserver()
+
+    def test_observer_returns_true_for_matching_node(self):
+        root = etree.XML("<div><row/></div>")
+        node = root[0]
+        result = self.observer.observe(node)
+        self.assertTrue(result)
+
+    def test_observer_returns_false_for_non_matching_node(self):
+        root = etree.XML("<div><table><row/></table></div>")
+        node = root.find(".//row")
+        result = self.observer.observe(node)
+        self.assertEqual(result, False)
+
+    def test_observer_identifies_matching_nodes(self):
+        elements = [
+            etree.XML("<p><row/></p>"),
+            etree.XML("<div><row></row></div>"),
+            etree.XML("<div><row><cell/></row></div>"),
+            etree.XML("<div><row><cell>text</cell></row></div>"),
+            etree.XML("<table><row><cell><row/></cell></row></table>"),
+            etree.XML("<div><row>text</row></div>"),
+            etree.XML(
+                """
+                <TEI>
+                  <teiHeader/>
+                  <text>
+                    <body>
+                      <div>
+                        <p>text
+                          <hi>text
+                            <row>
+                              <cell>text</cell>
+                            </row>
+                          </hi>
+                        </p>
+                      </div>
+                    </body>
+                  </text>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI>
+                  <teiHeader/>
+                  <text>
+                    <body>
+                      <div>
+                          <head>text
+                            <row>
+                              <cell>text</cell>
+                            </row>tail
+                        </head>
+                        <p>text
+                        </p>
+                      </div>
+                    </body>
+                  </text>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='ns'>
+                  <teiHeader/>
+                  <text>
+                    <body>
+                      <div>
+                        <row>
+                          <cell>text</cell>
+                        </row>
+                      </div>
+                    </body>
+                  </text>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='ns'>
+                  <teiHeader/>
+                  <text>
+                    <body>
+                      <div>
+                        <p>text</p>
+                        <row>
+                          <cell>text</cell>
+                        </row>
+                        <table>
+                          <row>
+                            <cell>text</cell>
+                          </row>
+                        </table>
+                      </div>
+                    </body>
+                  </text>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='ns'>
+                  <teiHeader/>
+                  <text>
+                    <body>
+                      <div>
+                        <table>
+                          <row>
+                            <cell>text
+                              <row>
+                                <cell>text</cell>tail
+                              </row>tail
+                            </cell>
+                          </row>
+                        </table>
+                      </div>
+                    </body>
+                  </text>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='ns'>
+                  <teiHeader/>
+                  <text>
+                    <body>
+                      <div>
+                        <p>
+                        <row>
+                          <cell>text</cell>
+                        </row>
+                        </p>
+                      </div>
+                    </body>
+                  </text>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='ns'>
+                  <teiHeader/>
+                  <text>
+                    <body>
+                      <div>
+                        <p>
+                          <list>
+                            <item>
+                              <row>
+                                <cell>text</cell>
+                              </row>
+                            </item>
+                          </list>
+                        </p>
+                      </div>
+                    </body>
+                  </text>
+                </TEI>
+                """
+            ),
+        ]
+        for element in elements:
+            result = [self.observer.observe(node) for node in element.iter()]
+            with self.subTest():
+                print(etree.tostring(element))
+                self.assertEqual(sum(result), 1)
+
+    def test_observer_ignores_non_matching_nodes(self):
+        elements = [
+            etree.XML("<table><row/></table>"),
+            etree.XML("<table><row/><row><cell/></row></table>"),
+            etree.XML("<div><table><row><cell>text</cell></row></table></div>"),
+            etree.XML(
+                "<table><row><cell><table><row><cell/></row></table></cell></row></table>"
+            ),
+            etree.XML("<table><row><cell>text</cell><cell>text</cell></row></table>"),
+            etree.XML("<div><head><table><row/></table></head></div>"),
+            etree.XML(
+                "<div><p>text<table><row><cell>text</cell><cell/></row></table></p></div>"
+            ),
+            etree.XML(
+                "<div><p><table><row><cell/><cell/></row><row><cell>text</cell></row></table></p></div>"
+            ),
+            etree.XML(
+                """
+                <TEI>
+                <teiHeader/>
+                <text>
+                  <body>
+                    <div>
+                      <p>text<table><row><cell>text</cell></row></table>tail</p>
+                    </div>
+                  </body>
+                </text>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='ns'>
+                  <teiHeader/>
+                  <text>
+                    <body>
+                      <div>
+                        <p>text</p>
+                        <p>
+                          <table>
+                            <row>
+                              <cell>
+                                <table>
+                                  <row/>
+                                </table>
+                              </cell>
+                            </row>
+                          </table>
+                        </p>tail
+                        <p>more text</p>
+                      </div>
+                    </body>
+                  </text>
+                </TEI>
+                """
+            ),
+        ]
+        for element in elements:
+            result = {self.observer.observe(node) for node in element.iter()}
+            with self.subTest():
+                self.assertEqual(result, {False})

--- a/tests/test_lonely_row_observer.py
+++ b/tests/test_lonely_row_observer.py
@@ -173,7 +173,6 @@ class LonelyRowObserverTester(unittest.TestCase):
         for element in elements:
             result = [self.observer.observe(node) for node in element.iter()]
             with self.subTest():
-                print(etree.tostring(element))
                 self.assertEqual(sum(result), 1)
 
     def test_observer_ignores_non_matching_nodes(self):
@@ -237,3 +236,308 @@ class LonelyRowObserverTester(unittest.TestCase):
             result = {self.observer.observe(node) for node in element.iter()}
             with self.subTest():
                 self.assertEqual(result, {False})
+
+    def test_table_element_added_as_parent(self):
+        root = etree.XML("<div><row><cell/></row></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertEqual(root[0].tag, "table")
+
+    def test_table_element_added_as_parent_with_namespace(self):
+        root = etree.XML(
+            """
+            <TEI xmlns='ns'>
+              <text><div>
+                <row>
+                  <cell>text</cell>
+                </row>
+              </div></text>
+            </TEI>
+            """
+        )
+        node = root.find(".//{*}row")
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//{*}table") is not None)
+
+    def test_lonely_empty_row_removed(self):
+        root = etree.XML("<div><row/></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertEqual(len(root), 0)
+
+    def test_attributes_of_row_preserved_after_transformation(self):
+        root = etree.XML("<div><row attr='val'><cell>text</cell></row></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        result = root.find(".//row").attrib
+        self.assertEqual(result, {"attr": "val"})
+
+    def test_children_preserved_after_transformation(self):
+        root = etree.XML(
+            """
+            <div>
+              <row>
+                <cell>data</cell>
+                <cell><floatingText/></cell>
+                <cell><list><item>text</item></list></cell>
+                <cell><p>text2</p>tail</cell>
+                <cell>text3</cell>
+              </row>
+            </div>
+            """
+        )
+        node = root[0]
+        self.observer.transform_node(node)
+        result = [elem.tag for elem in root.find(".//table/row").iter()]
+        self.assertEqual(
+            result,
+            [
+                "row",
+                "cell",
+                "cell",
+                "floatingText",
+                "cell",
+                "list",
+                "item",
+                "cell",
+                "p",
+                "cell",
+            ],
+        )
+
+    def test_attributes_of_row_preserved_after_transformation_with_namespace(self):
+        root = etree.XML(
+            "<TEI xmlns='ns'><div><row attr='val'><cell/></row></div></TEI>"
+        )
+        node = root.find(".//{*}row")
+        self.observer.transform_node(node)
+        self.assertEqual(root.find(".//{*}row").attrib, {"attr": "val"})
+
+    def test_multiple_adjacent_rows_added_to_same_table_element(self):
+        root = etree.XML(
+            """<div>
+                <row>
+                    <cell/>
+                </row>
+                <row>
+                    <cell/>
+                </row>
+                <row>
+                    <cell/>
+                    <cell/>
+                </row>
+                <row>
+                    <cell>text</cell>
+                </row>
+              </div>"""
+        )
+        for node in root.iter():
+            if self.observer.observe(node):
+                self.observer.transform_node(node)
+        self.assertTrue(len(root.findall(".//table")), 1)
+
+    def test_multiple_adjacent_rows_added_to_same_table_element_with_namespace(self):
+        root = etree.XML(
+            """
+            <TEI xmlns='ns'>
+                <text>
+                  <body>
+                    <div>
+                        <row>
+                            <cell/>
+                        </row>
+                        <row>
+                            <cell/>
+                        </row>
+                        <row>
+                            <cell/>
+                            <cell/>
+                        </row>
+                        <row>
+                            <cell>text</cell>
+                        </row>
+                    </div>
+                  </body>
+                </text>
+            </TEI>
+            """
+        )
+        for node in root.iter():
+            if self.observer.observe(node):
+                self.observer.transform_node(node)
+        self.assertTrue(len(root.findall(".//{*}table")), 1)
+
+    def test_empty_rows_not_added_to_table_with_multiple_adjacent_rows(self):
+        root = etree.XML(
+            """<div>
+                <row/>
+                <row>
+                    <cell/>
+                </row>
+                <row/>
+                <row>
+                    <cell/>
+                </row>
+                <row>
+                    <cell/>
+                    <cell/>
+                </row>
+                <row/>
+                <row>
+                    <cell>text</cell>
+                </row>
+              </div>"""
+        )
+        for node in root.iter():
+            if self.observer.observe(node):
+                self.observer.transform_node(node)
+        self.assertTrue(len(root.findall(".//table/row")), 4)
+
+    def test_observer_action_performed_on_nested_row(self):
+        root = etree.XML(
+            "<div><table><row><cell><row><cell/></row></cell></row></table></div>"
+        )
+        node = root.findall(".//row")[1]
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//table//table") is not None)
+
+    def test_observer_action_performed_on_nested_row_with_namespace(self):
+        root = etree.XML(
+            """
+            <TEI xmlns='ns'>
+              <text>
+                <div>
+                  <p>
+                    <table>
+                      <row>
+                        <cell>
+                          <row>
+                            <cell>text</cell>
+                          </row>
+                        </cell>
+                      </row>
+                    </table>
+                  </p>
+                </div>
+              </text>
+            </TEI>
+            """
+        )
+        node = root.findall(".//{*}row")[1]
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//{*}table//{*}table") is not None)
+
+    def test_nested_empty_row_removed(self):
+        root = etree.XML("<div><table><row><cell><row/></cell></row></table></div>")
+        node = root.find(".//cell/row")
+        self.observer.transform_node(node)
+        self.assertEqual(len(root.find(".//cell")), 0)
+
+    def test_nested_empty_row_removed_with_namespace(self):
+        root = etree.XML(
+            """
+            <TEI xmlns='ns'>
+              <div>
+                <table>
+                  <row>
+                    <cell>
+                      <row>
+                      </row>
+                    </cell>
+                  </row>
+                </table>
+              </div>
+            </TEI>
+            """
+        )
+        node = root.find(".//{*}cell/{*}row")
+        self.observer.transform_node(node)
+        self.assertEqual(len(root.find(".//{*}cell")), 0)
+
+    def test_tail_on_lonely_row_transfered_to_new_table_parent(self):
+        root = etree.XML(
+            """
+            <div>
+              <p>text
+                <row>
+                  <cell>data</cell>
+                </row>tail
+              </p>
+            </div>
+            """
+        )
+        node = root.find(".//row")
+        self.observer.transform_node(node)
+        result = root.find(".//table").tail.strip()
+        self.assertEqual(result, "tail")
+
+    def test_tail_removed_from_lonely_row_after_transformation(self):
+        root = etree.XML(
+            """
+            <div>
+              <p>text
+                <row>
+                  <cell>data</cell>
+                </row>tail
+              </p>
+            </div>
+            """
+        )
+        node = root.find(".//row")
+        self.observer.transform_node(node)
+        result = root.find(".//row").tail
+        self.assertEqual(result, None)
+
+    def test_tails_on_multiple_rows_concatenated_and_added_to_table_parent(self):
+        root = etree.XML(
+            """
+            <div>
+              <p>text
+                <row>
+                  <cell>data</cell>
+                </row>a
+                <row>
+                  <cell/>
+                </row>b
+                <row>
+                  <cell/>
+                </row>c
+              </p>
+            </div>
+            """
+        )
+        for node in root.iter():
+            if self.observer.observe(node):
+                self.observer.transform_node(node)
+        result = root.find(".//table").tail
+        self.assertEqual(result, "a b c")
+
+    def test_row_without_children_but_with_text_not_removed(self):
+        root = etree.XML("<div><row>text</row></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertEqual(root[0].tag, "table")
+
+    def test_row_without_children_but_with_tail_not_removed(self):
+        root = etree.XML("<div><p><row/>tail</p></div>")
+        node = root[0][0]
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//table") is not None)
+
+    def test_multiple_table_elements_inserted_if_lonely_rows_not_adjacent(self):
+        root = etree.XML(
+            """
+            <div>
+              <row><cell>first</cell></row>
+              <row><cell>first</cell></row>
+              <p>intermediate text</p>
+              <row><cell>second</cell></row>
+              <p>second intermediate text</p>
+              <row><cell>third</cell></row>
+            </div>
+            """
+        )
+        for node in root.iter():
+            if self.observer.observe(node):
+                self.observer.transform_node(node)
+        self.assertEqual(len(root.findall(".//table")), 3)

--- a/tests/test_use_case_impl.py
+++ b/tests/test_use_case_impl.py
@@ -688,6 +688,14 @@ class UseCaseTester(unittest.TestCase):
         ]
         self.assertEqual(result, expected)
 
+    def test_lonely_row_wrapped_in_table(self):
+        file = os.path.join(self.data, "file_with_lonely_row.xml")
+        request = CliRequest(file, ["lonely-row"])
+        self.use_case.process(request)
+        _, output = self.xml_writer.assertSingleDocumentWritten()
+        result = self.tei_validator.validate(output)
+        self.assertTrue(result)
+
     def file_invalid_because_classcode_misspelled(self, file):
         logs = self._get_validation_error_logs_for_file(file)
         expected_error_msg = "Did not expect element classcode there"

--- a/tests/testdata/file_with_lonely_row.xml
+++ b/tests/testdata/file_with_lonely_row.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <funder>Funder</funder>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <extent>76</extent>
+      <publicationStmt>
+        <publisher>Publisher</publisher>
+        <address>
+          <addrLine>address at city</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+        <authority>
+          <name/>
+        </authority>
+      </publicationStmt>
+      <notesStmt>
+        <note type="source" anchored="true">CD</note>
+        <note type="type">
+          <idno type="date">2022-07-20</idno>
+        </note>
+      </notesStmt>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date type="first">2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="series">Series</idno>
+              <idno type="volume">1</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <editionStmt>
+            <edition>edition</edition>
+          </editionStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date>2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">Series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="bibl">bibl info</idno>
+              <idno type="series">Series</idno>
+              <idno type="page_first">11</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <bibl></bibl>
+        </taxonomy>
+      </classDecl>
+      <projectDesc default="false">
+        <p>Project</p>
+      </projectDesc>
+      <samplingDecl default="false">
+        <p>description how the file was changed</p>
+      </samplingDecl>
+    </encodingDesc>
+    <profileDesc>
+      <textClass default="false">
+        <keywords scheme="#tax">
+          <term n="1" type="main">class</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change>0</change>
+      <change when="2022-07-21"><name>Other Person</name>Change description</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div>
+        <p>
+          <row>
+            <cell>
+              <row>
+                <cell>text</cell>
+              </row>
+            </cell>
+          </row>
+          <row/>
+          <row>
+            <cell>text</cell>
+          </row>
+        </p>
+        <row><cell>text</cell></row>
+    </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
Implement *lonely-row* plugin:
Wrap lonely `<row/>` elements in `<table/>` or remove them, if they are empty.