### PR TITLE
Refactor TeiTransformer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tei-transform"
-version = "0.0.2"
+version = "0.0.3"
 authors = [{name="Luise Köhler", email="luise.koehler@bbaw.de"}]
 description = "Fix errors in xml document that make it invalid according to TEI P5"
 readme = "README.md"

--- a/tei_transform/cli/use_case.py
+++ b/tei_transform/cli/use_case.py
@@ -49,8 +49,10 @@ class TeiTransformationUseCaseImpl:
         Processes cli arguments and applies them to the transformation
         of an xml tree.
         """
-        observer_list = self.observer_constructor.construct_observers(request.observers)
-        self.tei_transformer.set_list_of_observers(observer_list)
+        observer_lists = self.observer_constructor.construct_observers(
+            request.observers
+        )
+        self.tei_transformer.set_list_of_observers(observer_lists)
         change = None
         if request.config is not None:
             change = construct_change_from_config_file(request.config)

--- a/tests/test_observer_constructor.py
+++ b/tests/test_observer_constructor.py
@@ -2,8 +2,10 @@ import random
 import unittest
 from importlib import metadata
 
+from tei_transform.abstract_node_observer import AbstractNodeObserver
 from tei_transform.observer import (
     DivParentObserver,
+    DivSiblingObserver,
     DoublePlikeObserver,
     FilenameElementObserver,
     PAsDivSiblingObserver,
@@ -16,7 +18,7 @@ class ObserverConstructorTester(unittest.TestCase):
         self.constructor = ObserverConstructor()
 
     def test_observer_construction(self):
-        test_observer = self.constructor.construct_observers(["filename-element"])[0]
+        test_observer = self.constructor.construct_observers(["filename-element"])[0][0]
         self.assertTrue(isinstance(test_observer, FilenameElementObserver))
 
     def test_exception_raised_if_observer_is_not_registered_as_plugin(self):
@@ -34,46 +36,16 @@ class ObserverConstructorTester(unittest.TestCase):
             InvalidObserver, self.constructor.construct_observers, ["fake-observer"]
         )
 
-    def test_p_as_div_sibling_observer_always_added_last(self):
+    def test_double_p_like_observer_added_last(self):
         plugins = list(self.constructor.plugins_by_name.keys())
         for _ in range(10):
             plugins_to_use = random.sample(plugins, random.randint(1, len(plugins)))
-            # make sure p-div-sibling is in plugin list
-            if "p-div-sibling" not in plugins_to_use:
-                plugins_to_use.append("p-div-sibling")
-            random.shuffle(plugins_to_use)
-            observer_list = self.constructor.construct_observers(plugins_to_use)
-            with self.subTest():
-                self.assertTrue(isinstance(observer_list[-1], PAsDivSiblingObserver))
-
-    def test_double_p_like_observer_added_last_if_p_div_sibling_not_present(self):
-        plugins = list(self.constructor.plugins_by_name.keys())
-        for _ in range(10):
-            plugins_to_use = random.sample(plugins, random.randint(1, len(plugins)))
-            # make sure double-plike is in plugin list
-            plugins_to_use = [
-                plugin for plugin in plugins_to_use if plugin != "p-div-sibling"
-            ]
             if "double-plike" not in plugins_to_use:
                 plugins_to_use.append("double-plike")
             random.shuffle(plugins_to_use)
             observer_list = self.constructor.construct_observers(plugins_to_use)
             with self.subTest():
-                self.assertTrue(isinstance(observer_list[-1], DoublePlikeObserver))
-
-    def test_double_p_like_observer_added_second_to_last_if_p_div_sibling_present(self):
-        plugins = list(self.constructor.plugins_by_name.keys())
-        for _ in range(10):
-            plugins_to_use = random.sample(plugins, random.randint(1, len(plugins)))
-            # make sure double-plike and p-div-sibling are in plugin list
-            if "double-plike" not in plugins_to_use:
-                plugins_to_use.append("double-plike")
-            if "p-div-sibling" not in plugins_to_use:
-                plugins_to_use.append("p-div-sibling")
-            random.shuffle(plugins_to_use)
-            observer_list = self.constructor.construct_observers(plugins_to_use)
-            with self.subTest():
-                self.assertTrue(isinstance(observer_list[-2], DoublePlikeObserver))
+                self.assertTrue(isinstance(observer_list[0][-1], DoublePlikeObserver))
 
     def test_div_parent_observer_always_at_front(self):
         plugins = list(self.constructor.plugins_by_name.keys())
@@ -85,4 +57,74 @@ class ObserverConstructorTester(unittest.TestCase):
             random.shuffle(plugins_to_use)
             observer_list = self.constructor.construct_observers(plugins_to_use)
             with self.subTest():
-                self.assertTrue(isinstance(observer_list[0], DivParentObserver))
+                self.assertTrue(isinstance(observer_list[0][0], DivParentObserver))
+
+    def test_observers_sorted_in_two_lists(self):
+        plugins = list(self.constructor.plugins_by_name.keys())
+        first_pass, second_pass = self.constructor.construct_observers(plugins)
+        self.assertTrue(isinstance(first_pass, list) and isinstance(second_pass, list))
+        self.assertTrue(
+            all(
+                isinstance(observer, AbstractNodeObserver)
+                for observer in first_pass + second_pass
+            )
+        )
+
+    def test_div_sibling_observers_in_second_list(self):
+        plugins = list(self.constructor.plugins_by_name.keys())
+        for _ in range(10):
+            plugins_to_use = random.sample(plugins, random.randint(1, len(plugins)))
+            # make sure div-sibling pluings are in list
+            if "div-sibling" not in plugins_to_use:
+                plugins_to_use.append("div-sibling")
+            if "p-div-sibling" not in plugins_to_use:
+                plugins_to_use.append("p-div-sibling")
+            random.shuffle(plugins_to_use)
+            _, second_pass = self.constructor.construct_observers(plugins_to_use)
+            with self.subTest():
+                self.assertEqual(
+                    set(
+                        isinstance(observer, PAsDivSiblingObserver)
+                        or isinstance(observer, DivSiblingObserver)
+                        for observer in second_pass
+                    ),
+                    {True},
+                )
+
+    def test_div_sibling_observers_in_not_in_first_list(self):
+        plugins = list(self.constructor.plugins_by_name.keys())
+        for _ in range(10):
+            plugins_to_use = random.sample(plugins, random.randint(1, len(plugins)))
+            # make sure div-sibling pluings are in list
+            if "div-sibling" not in plugins_to_use:
+                plugins_to_use.append("div-sibling")
+            if "p-div-sibling" not in plugins_to_use:
+                plugins_to_use.append("p-div-sibling")
+            random.shuffle(plugins_to_use)
+            first_pass, _ = self.constructor.construct_observers(plugins_to_use)
+            with self.subTest():
+                self.assertEqual(
+                    set(
+                        isinstance(observer, PAsDivSiblingObserver)
+                        or isinstance(observer, DivSiblingObserver)
+                        for observer in first_pass
+                    ),
+                    {False},
+                )
+
+    def test_second_observer_list_empty_if_div_sibling_plugins_not_used(self):
+        plugins = list(self.constructor.plugins_by_name.keys())
+        for _ in range(10):
+            plugins_to_use = random.sample(plugins, random.randint(1, len(plugins)))
+            # remove div-sibling plugins from list
+            plugins_to_use = [
+                plugin
+                for plugin in plugins_to_use
+                if plugin not in {"p-div-sibling", "div-sibling"}
+            ]
+            if "double-plike" not in plugins_to_use:
+                plugins_to_use.append("double-plike")
+            random.shuffle(plugins_to_use)
+            _, second_pass = self.constructor.construct_observers(plugins_to_use)
+            with self.subTest():
+                self.assertEqual([], second_pass)

--- a/tests/test_observer_constructor.py
+++ b/tests/test_observer_constructor.py
@@ -94,7 +94,7 @@ class ObserverConstructorTester(unittest.TestCase):
     def test_div_sibling_observers_in_not_in_first_list(self):
         plugins = list(self.constructor.plugins_by_name.keys())
         for _ in range(10):
-            plugins_to_use = random.sample(plugins, random.randint(1, len(plugins)))
+            plugins_to_use = random.sample(plugins, random.randint(3, len(plugins)))
             # make sure div-sibling pluings are in list
             if "div-sibling" not in plugins_to_use:
                 plugins_to_use.append("div-sibling")

--- a/tests/test_observer_constructor.py
+++ b/tests/test_observer_constructor.py
@@ -122,8 +122,6 @@ class ObserverConstructorTester(unittest.TestCase):
                 for plugin in plugins_to_use
                 if plugin not in {"p-div-sibling", "div-sibling"}
             ]
-            if "double-plike" not in plugins_to_use:
-                plugins_to_use.append("double-plike")
             random.shuffle(plugins_to_use)
             _, second_pass = self.constructor.construct_observers(plugins_to_use)
             with self.subTest():

--- a/tests/test_tei_transformer.py
+++ b/tests/test_tei_transformer.py
@@ -15,7 +15,7 @@ class TeiTransformerTester(unittest.TestCase):
         self.transformer = TeiTransformer(FakeIterator())
 
     def test_tree_constructed_correctly(self):
-        self.transformer.set_list_of_observers([FakeObserver()])
+        self.transformer.set_list_of_observers(([FakeObserver()], []))
         xml = io.BytesIO(
             b"""<TEI>
         <first>text</first>
@@ -30,7 +30,7 @@ class TeiTransformerTester(unittest.TestCase):
 
     def test_no_tree_constructed_if_tei_node_missing(self):
         transformer = TeiTransformer(self.iterator)
-        transformer.set_list_of_observers([FakeObserver()])
+        transformer.set_list_of_observers(([FakeObserver()], []))
         xml = io.BytesIO(
             b"""<someTag>
         <first>text</first>
@@ -43,7 +43,7 @@ class TeiTransformerTester(unittest.TestCase):
 
     def test_transformer_interaction_with_iterator(self):
         transformer = TeiTransformer(self.iterator)
-        transformer.set_list_of_observers([FakeObserver()])
+        transformer.set_list_of_observers(([FakeObserver()], []))
         xml = io.BytesIO(
             b"""
         <TEI>
@@ -62,7 +62,7 @@ class TeiTransformerTester(unittest.TestCase):
 
     def test_transformer_interaction_with_iterator_with_namespace(self):
         transformer = TeiTransformer(self.iterator)
-        transformer.set_list_of_observers([FakeObserver()])
+        transformer.set_list_of_observers(([FakeObserver()], []))
         xml = io.BytesIO(
             b"""
             <TEI xmlns="http://www.tei-c.org/ns/1.0">
@@ -84,7 +84,7 @@ class TeiTransformerTester(unittest.TestCase):
 
     def test_observer_performs_tag_change_when_matching_node_found(self):
         self.transformer.set_list_of_observers(
-            [FakeObserver("match", action=change_tag)]
+            ([FakeObserver("match", action=change_tag)], [])
         )
         xml = io.BytesIO(
             b"""<TEI>
@@ -101,7 +101,7 @@ class TeiTransformerTester(unittest.TestCase):
 
     def test_attribute_change_on_observer_activation(self):
         self.transformer.set_list_of_observers(
-            [FakeObserver("match", action=remove_id_attrib)]
+            ([FakeObserver("match", action=remove_id_attrib)], [])
         )
         xml = io.BytesIO(
             b"""
@@ -120,7 +120,7 @@ class TeiTransformerTester(unittest.TestCase):
 
     def test_observer_doesnt_perform_change_on_non_matching_node(self):
         self.transformer.set_list_of_observers(
-            [FakeObserver("match", action=remove_id_attrib)]
+            ([FakeObserver("match", action=remove_id_attrib)], [])
         )
         xml = io.BytesIO(
             b"""
@@ -138,7 +138,7 @@ class TeiTransformerTester(unittest.TestCase):
     def test_transformation_with_multiple_observers_on_sibling_nodes(self):
         tag_observer = FakeObserver("tag-to-change", action=change_tag)
         id_observer = FakeObserver("match", action=remove_id_attrib)
-        self.transformer.set_list_of_observers([tag_observer, id_observer])
+        self.transformer.set_list_of_observers(([tag_observer, id_observer], []))
         xml = io.BytesIO(
             b"""
         <TEI>
@@ -160,7 +160,7 @@ class TeiTransformerTester(unittest.TestCase):
     def test_transformation_with_multiple_observers_on_nested_nodes(self):
         tag_observer = FakeObserver("tag-to-change", action=change_tag)
         id_observer = FakeObserver("match", action=remove_id_attrib)
-        self.transformer.set_list_of_observers([tag_observer, id_observer])
+        self.transformer.set_list_of_observers(([tag_observer, id_observer], []))
         xml = io.BytesIO(
             b"""
         <TEI>
@@ -181,7 +181,7 @@ class TeiTransformerTester(unittest.TestCase):
     def test_two_observers_activate_on_same_node(self):
         id_observer = FakeObserver("match", action=remove_id_attrib)
         tag_observer = FakeObserver("match", action=change_tag)
-        self.transformer.set_list_of_observers([id_observer, tag_observer])
+        self.transformer.set_list_of_observers(([id_observer, tag_observer], []))
         xml = io.BytesIO(
             b"""
         <TEI>
@@ -198,7 +198,7 @@ class TeiTransformerTester(unittest.TestCase):
     def test_two_observers_activate_on_same_node_with_conflicting_actions(self):
         tag_observer = FakeObserver("match", action=change_tag)
         id_observer = FakeObserver("match", action=remove_id_attrib)
-        self.transformer.set_list_of_observers([tag_observer, id_observer])
+        self.transformer.set_list_of_observers(([tag_observer, id_observer], []))
         xml = io.BytesIO(
             b"""
         <TEI>
@@ -214,20 +214,22 @@ class TeiTransformerTester(unittest.TestCase):
 
     def test_returns_none_when_file_is_empty(self):
         transformer = TeiTransformer(self.iterator)
-        transformer.set_list_of_observers([FakeObserver()])
+        transformer.set_list_of_observers(([FakeObserver()], []))
         xml = io.BytesIO(b"")
         result = transformer.perform_transformation(xml)
         self.assertIsNone(result)
 
     def test_change_info_recorded_if_tree_changed(self):
         transformer = TeiTransformer(FakeIterator())
-        transformer.set_list_of_observers([FakeObserver("oldTag", action=change_tag)])
+        transformer.set_list_of_observers(
+            ([FakeObserver("oldTag", action=change_tag)], [])
+        )
         xml = io.BytesIO(b"<someTag><oldTag/></someTag>")
         transformer.perform_transformation(xml)
         self.assertTrue(transformer.xml_tree_changed())
 
     def test_no_change_recorded_if_tree_hasnt_changed(self):
-        self.transformer.set_list_of_observers([FakeObserver()])
+        self.transformer.set_list_of_observers(([FakeObserver()], []))
         xml = io.BytesIO(b"<someTag><oldTag/></someTag>")
         self.transformer.perform_transformation(xml)
         self.assertFalse(self.transformer.xml_tree_changed())
@@ -238,7 +240,7 @@ class TeiTransformerTester(unittest.TestCase):
             date="2022-07-25",
             reason="Change reason",
         )
-        self.transformer.set_list_of_observers([FakeObserver()])
+        self.transformer.set_list_of_observers(([FakeObserver()], []))
         xml = etree.parse(
             io.BytesIO(
                 b"<teiHeader><revisionDesc><change>0</change></revisionDesc></teiHeader>"
@@ -256,7 +258,7 @@ class TeiTransformerTester(unittest.TestCase):
             date="2022-07-25",
             reason="Change reason",
         )
-        self.transformer.set_list_of_observers([FakeObserver()])
+        self.transformer.set_list_of_observers(([FakeObserver()], []))
         xml = etree.parse(
             io.BytesIO(
                 b"""<TEI xmlns='http://www.tei-c.org/ns/1.0'>
@@ -282,7 +284,7 @@ class TeiTransformerTester(unittest.TestCase):
             date="2022-07-25",
             reason="Change reason",
         )
-        self.transformer.set_list_of_observers([FakeObserver()])
+        self.transformer.set_list_of_observers(([FakeObserver()], []))
         xml = etree.parse(
             io.BytesIO(
                 b"""<teiHeader>
@@ -304,7 +306,7 @@ class TeiTransformerTester(unittest.TestCase):
             date="2022-07-25",
             reason="Change reason",
         )
-        self.transformer.set_list_of_observers([FakeObserver()])
+        self.transformer.set_list_of_observers(([FakeObserver()], []))
         xml = etree.parse(
             io.BytesIO(b"<TEI><teiHeader><fileDesc/><profileDesc/></teiHeader></TEI>")
         ).getroot()
@@ -329,7 +331,7 @@ class TeiTransformerTester(unittest.TestCase):
             date="2022-07-25",
             reason="Change reason",
         )
-        self.transformer.set_list_of_observers([FakeObserver()])
+        self.transformer.set_list_of_observers(([FakeObserver()], []))
         xml = etree.parse(
             io.BytesIO(
                 b"""<TEI xmlns='http://www.tei-c.org/ns/1.0'>
@@ -346,7 +348,7 @@ class TeiTransformerTester(unittest.TestCase):
             date="2022-07-25",
             reason="Change reason",
         )
-        self.transformer.set_list_of_observers([FakeObserver()])
+        self.transformer.set_list_of_observers(([FakeObserver()], []))
         xml = etree.parse(
             io.BytesIO(
                 b"<teiHeader><revisionDesc><change>0</change></revisionDesc></teiHeader>"
@@ -363,7 +365,7 @@ class TeiTransformerTester(unittest.TestCase):
             date="2022-07-25",
             reason="Change reason",
         )
-        self.transformer.set_list_of_observers([FakeObserver()])
+        self.transformer.set_list_of_observers(([FakeObserver()], []))
         xml = etree.parse(
             io.BytesIO(
                 b"<teiHeader><revisionDesc><change>0</change></revisionDesc></teiHeader>"
@@ -383,7 +385,7 @@ class TeiTransformerTester(unittest.TestCase):
             date="2022-07-25",
             reason="Change reason",
         )
-        self.transformer.set_list_of_observers([FakeObserver()])
+        self.transformer.set_list_of_observers(([FakeObserver()], []))
         xml = etree.parse(
             io.BytesIO(
                 b"<teiHeader><revisionDesc><change>0</change></revisionDesc></teiHeader>"
@@ -400,7 +402,7 @@ class TeiTransformerTester(unittest.TestCase):
             date="2022-07-25",
             reason="Change reason",
         )
-        self.transformer.set_list_of_observers([FakeObserver()])
+        self.transformer.set_list_of_observers(([FakeObserver()], []))
         xml = etree.parse(
             io.BytesIO(
                 b"<teiHeader><revisionDesc><change>0</change></revisionDesc></teiHeader>"
@@ -417,7 +419,7 @@ class TeiTransformerTester(unittest.TestCase):
             date="2022-07-25",
             reason="Change reason",
         )
-        self.transformer.set_list_of_observers([FakeObserver()])
+        self.transformer.set_list_of_observers(([FakeObserver()], []))
         xml = etree.parse(
             io.BytesIO(
                 b"<teiHeader><revisionDesc><change>0</change></revisionDesc></teiHeader>"
@@ -434,7 +436,7 @@ class TeiTransformerTester(unittest.TestCase):
             date="2022-07-25",
             reason="Change reason",
         )
-        self.transformer.set_list_of_observers([FakeObserver()])
+        self.transformer.set_list_of_observers(([FakeObserver()], []))
         xml = etree.parse(
             io.BytesIO(
                 b"<teiHeader><revisionDesc><change>0</change></revisionDesc></teiHeader>"
@@ -447,7 +449,7 @@ class TeiTransformerTester(unittest.TestCase):
 
     def test_no_person_name_inserted_if_missing(self):
         change = RevisionDescChange(person=[], date="2022-02-20", reason="Some reason")
-        self.transformer.set_list_of_observers([FakeObserver()])
+        self.transformer.set_list_of_observers(([FakeObserver()], []))
         xml = etree.parse(
             io.BytesIO(
                 b"<teiHeader><revisionDesc><change>0</change></revisionDesc></teiHeader>"
@@ -458,7 +460,7 @@ class TeiTransformerTester(unittest.TestCase):
         self.assertEqual(result, ["teiHeader", "revisionDesc", "change", "change"])
 
     def test_namespace_to_tei_element_added_if_tei_namespace_observer_is_passed(self):
-        self.transformer.set_list_of_observers([TeiNamespaceObserver()])
+        self.transformer.set_list_of_observers(([TeiNamespaceObserver()], []))
         xml = io.BytesIO(
             b"""
         <TEI>
@@ -474,7 +476,7 @@ class TeiTransformerTester(unittest.TestCase):
         self.assertTrue("http://www.tei-c.org/ns/1.0" in tree.nsmap.values())
 
     def test_tei_namespace_added_to_child_nodes(self):
-        self.transformer.set_list_of_observers([TeiNamespaceObserver()])
+        self.transformer.set_list_of_observers(([TeiNamespaceObserver()], []))
         xml = io.BytesIO(
             b"""
         <TEI>
@@ -506,7 +508,7 @@ class TeiTransformerTester(unittest.TestCase):
         )
         transformer = TeiTransformer(FakeIterator())
         transformer.set_list_of_observers(
-            [FakeObserver(tag="oldTag", action=change_tag)]
+            ([FakeObserver(tag="oldTag", action=change_tag)], [])
         )
         doc1 = io.BytesIO(
             b"""
@@ -574,6 +576,52 @@ class TeiTransformerTester(unittest.TestCase):
             rev_desc_added = tree.find(".//{*}revisionDesc") is not None
             result.append(rev_desc_added)
         self.assertEqual(result, [True, False, True, False])
+
+    def test_both_lists_of_observers_applied(self):
+        transformer = TeiTransformer(self.iterator)
+        transformer.set_list_of_observers(
+            (
+                [FakeObserver("match", action=change_tag)],
+                [FakeObserver("newTag", action=remove_id_attrib)],
+            )
+        )
+        xml = io.BytesIO(
+            b"""
+        <TEI>
+          <text>
+            <match id='matching node'>
+              <subnode attribute="not matching"/>
+            </match>
+          </text>
+        </TEI>
+        """
+        )
+        tree = transformer.perform_transformation(xml)
+        result = tree.find(".//newTag").attrib
+        self.assertEqual(result, {})
+
+    def test_both_lists_of_observers_applied_different_output_for_different_order(self):
+        transformer = TeiTransformer(self.iterator)
+        transformer.set_list_of_observers(
+            (
+                [FakeObserver("newTag", action=remove_id_attrib)],
+                [FakeObserver("match", action=change_tag)],
+            )
+        )
+        xml = io.BytesIO(
+            b"""
+        <TEI>
+          <text>
+            <match id='matching node'>
+              <subnode attribute="not matching"/>
+            </match>
+          </text>
+        </TEI>
+        """
+        )
+        tree = transformer.perform_transformation(xml)
+        result = tree.find(".//newTag").attrib
+        self.assertEqual(result, {"id": "matching node"})
 
 
 # helper functions for node transformation with FakeObserver

--- a/tests/test_use_case_impl.py
+++ b/tests/test_use_case_impl.py
@@ -806,6 +806,24 @@ class UseCaseTester(unittest.TestCase):
             with self.subTest():
                 self.assertTrue(result)
 
+    def test_combination_of_p_div_sibling_with_tail_text(self):
+        file = os.path.join(self.data, "file_with_tail_on_p.xml")
+        request = CliRequest(file, ["p-div-sibling", "tail-text"])
+        self.use_case.process(request)
+        _, output = self.xml_writer.assertSingleDocumentWritten()
+        result = self.tei_validator.validate(output)
+        self.assertTrue(result)
+
+    def test_combination_of_div_sibling_and_lonely_element_plugins(self):
+        file = os.path.join(self.data, "file_with_lonely_elems_next_to_div.xml")
+        request = CliRequest(
+            file, ["div-sibling", "lonely-row", "lonely-cell", "p-div-sibling"]
+        )
+        self.use_case.process(request)
+        _, output = self.xml_writer.assertSingleDocumentWritten()
+        result = self.tei_validator.validate(output)
+        self.assertTrue(result)
+
     def file_invalid_because_classcode_misspelled(self, file):
         logs = self._get_validation_error_logs_for_file(file)
         expected_error_msg = "Did not expect element classcode there"

--- a/tests/testdata/file_with_lonely_elems_next_to_div.xml
+++ b/tests/testdata/file_with_lonely_elems_next_to_div.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <funder>Funder</funder>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <extent>76</extent>
+      <publicationStmt>
+        <publisher>Publisher</publisher>
+        <address>
+          <addrLine>address at city</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+        <authority>
+          <name/>
+        </authority>
+      </publicationStmt>
+      <notesStmt>
+        <note type="source" anchored="true">CD</note>
+        <note type="type">
+          <idno type="date">2022-07-20</idno>
+        </note>
+      </notesStmt>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date type="first">2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="series">Series</idno>
+              <idno type="volume">1</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <editionStmt>
+            <edition>edition</edition>
+          </editionStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date>2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">Series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="bibl">bibl info</idno>
+              <idno type="series">Series</idno>
+              <idno type="page_first">11</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <bibl></bibl>
+        </taxonomy>
+      </classDecl>
+      <projectDesc default="false">
+        <p>Project</p>
+      </projectDesc>
+      <samplingDecl default="false">
+        <p>description how the file was changed</p>
+      </samplingDecl>
+    </encodingDesc>
+    <profileDesc>
+      <textClass default="false">
+        <keywords scheme="#tax">
+          <term n="1" type="main">class</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change>0</change>
+      <change when="2022-07-21"><name>Other Person</name>Change description</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div>
+      <div/>
+        <row>
+          <cell>
+            <row>
+              <cell>text</cell>
+            </row>
+          </cell>
+        </row>
+        <row/>
+        <row>
+          <cell>text</cell>
+        </row>
+        <p/>
+        <row><cell>text</cell></row>
+      <div/>
+      <div>
+        <div>
+          <p>text</p>
+        </div>
+        <cell>text</cell>
+      </div>
+    </div>
+    </body>
+  </text>
+</TEI>

--- a/tests/testdata/file_with_tail_on_p.xml
+++ b/tests/testdata/file_with_tail_on_p.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <funder>Funder</funder>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <extent>76</extent>
+      <publicationStmt>
+        <publisher>Publisher</publisher>
+        <address>
+          <addrLine>address at city</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+        <authority>
+          <name/>
+        </authority>
+      </publicationStmt>
+      <notesStmt>
+        <note type="source" anchored="true">CD</note>
+        <note type="type">
+          <idno type="date">2022-07-20</idno>
+        </note>
+      </notesStmt>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date type="first">2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="series">Series</idno>
+              <idno type="volume">1</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <editionStmt>
+            <edition>edition</edition>
+          </editionStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date>2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">Series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="bibl">bibl info</idno>
+              <idno type="series">Series</idno>
+              <idno type="page_first">11</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <bibl></bibl>
+        </taxonomy>
+      </classDecl>
+      <projectDesc default="false">
+        <p>Project</p>
+      </projectDesc>
+      <samplingDecl default="false">
+        <p>description how the file was changed</p>
+      </samplingDecl>
+    </encodingDesc>
+    <profileDesc>
+      <textClass default="false">
+        <keywords scheme="#tax">
+          <term n="1" type="main">class</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change>0</change>
+      <change when="2022-07-21"><name>Other Person</name>Change description</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div>
+        <p>A paragraph</p>
+      </div>
+      <p>Some more text</p>tail
+      <p/>tail
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
- Make two passes over xml-tree to catch invalid elements that were added by a transformation
- Split observers in two lists (for first pass and second pass over tree)
- Use only `DivSiblingObserver` and `PAsDivSiblingObserver` in second pass (change sorting in `ObserverConstructor`)