### PR TITLE
Refactor handling of tails

### DIFF
--- a/observer_docs/lonely-cell.md
+++ b/observer_docs/lonely-cell.md
@@ -1,7 +1,7 @@
 ## lonely-cell
 Find  `<cell/>` elements that are outside of a `<row/>` element and wrap them in `<row/>` and `<table/>`, if necessary.
 Adjacent `<cell/>` elements will be added to the same `<row/>` element to avoid adding a new `<row/>` and `<table/>` for each solitary `<cell/>`.
-If the `<cell/>` element has a tail, it will be moved to the `<table/>` element.
+If the `<cell/>` element has a tail, it will be concatenated with its text content.
 
 
 ### Example
@@ -48,9 +48,9 @@ After transformation:
   <p>
     <table>
       <row>
-        <cell>new table</cell>
+        <cell>new table tail</cell>
       </row>
-    </table>tail
+    </table>
   </p>
 </div>
 ```

--- a/observer_docs/lonely-row.md
+++ b/observer_docs/lonely-row.md
@@ -1,6 +1,6 @@
 ## lonely-row
 Find `<row/>` elements that are not a direct descendant of `<table/>` and add a new `<table/>` element as parent. Adjacent `<row/>` elements will be added to the same `<table/>` element. If the `<row/>` element is empty (i.e. doesn't have descendants, text, or tail), it is removed instead of wrapping it in a `<table/>` element.
-If the `<row/>` element has a tail, the tail is moved to the `<table/>` parent element or, if already existing, concatenated with the tail of the parent.
+If the `<row/>` element has a tail, the tail is moved to the last `<cell/>` element or, if `<row/>` has no children, a new `<cell/>` is added containg the tail.
 
 
 ### Example
@@ -33,9 +33,9 @@ After transformation:
       </row>
       <row>
         <cell>text2</cell>
-        <cell>text3</cell>
+        <cell>text3 tail</cell>
       </row>
-    </table>tail
+    </table>
   </p>
   <table>
     <row>

--- a/observer_docs/tail-text.md
+++ b/observer_docs/tail-text.md
@@ -1,6 +1,6 @@
 ## tail-text
-Remove tail of elements with tag `<p/>`, `<ab/>`, `<fw/>`, `<table/>`, or `<list/>` if the parent of the element is  ```<div/>```, `<body/>`, or `<floatingText/>`. A new ```<p/>``` element is added containing the former tail as next sibling of the original element and the tail is removed from it.
-If the element has tag `fw/` and is a direct child of `<floatingText/>`, `fw`  will be used the tag of the newly added element instead of `p` (as `<p/>` cannot appear as child of `<floatingText/>`)
+Remove tail of elements with tag `<p/>`, `<ab/>`, `<fw/>`, `<table/>`, or `<list/>` if the parent of the element is  ```<div/>```, `<body/>`, or `<floatingText/>`. A new ```<p/>``` element is added containing the former tail as next sibling of the original element and the tail is removed from the original element.
+If the element has tag `fw/` and is a direct child of `<floatingText/>`, `fw`  will be used as the tag of the newly added element instead of `p` (as `<p/>` cannot appear as child of `<floatingText/>`)
 
 ### Example
 Before transformation:

--- a/observer_docs/tail-text.md
+++ b/observer_docs/tail-text.md
@@ -1,11 +1,15 @@
 ## tail-text
-Remove tail of elements with tag ```<p/>, <ab/>, or <fw/>``` if the parent of the element is  ```<div/>```, `<body/>`, or `<floatingText/>`. A new ```<p/>``` element is added containing the former tail as next sibling of the original element and the tail is removed from it.
+Remove tail of elements with tag `<p/>`, `<ab/>`, `<fw/>`, `<table/>`, or `<list/>` if the parent of the element is  ```<div/>```, `<body/>`, or `<floatingText/>`. A new ```<p/>``` element is added containing the former tail as next sibling of the original element and the tail is removed from it.
 If the element has tag `fw/` and is a direct child of `<floatingText/>`, `fw`  will be used the tag of the newly added element instead of `p` (as `<p/>` cannot appear as child of `<floatingText/>`)
+
 ### Example
 Before transformation:
 ```xml
 <div>
   <p>text</p>tail
+  <div>
+    <table/>tail
+  </div>
 </div>
 ```
 
@@ -14,5 +18,8 @@ After transformation:
 <div>
   <p>text</p>
   <p>tail</p>
+  <div>
+    <table/>
+    <p>tail</p>
 </div>
 ```

--- a/tei_transform/observer/lonely_cell_observer.py
+++ b/tei_transform/observer/lonely_cell_observer.py
@@ -49,5 +49,12 @@ class LonelyCellObserver(AbstractNodeObserver):
                 self._new_table = new_table
                 parent = new_table
         if node.tail is not None and node.tail.strip():
+            self._handle_tail_on_item_element(node)
+
+    def _handle_tail_on_item_element(self, node: etree._Element) -> None:
+        if len(node) != 0:
+            last_child = node[-1]
+            last_child.tail = merge_text_content(last_child.tail, node.tail)
+        else:
             node.text = merge_text_content(node.text, node.tail)
-            node.tail = None
+        node.tail = None

--- a/tei_transform/observer/lonely_cell_observer.py
+++ b/tei_transform/observer/lonely_cell_observer.py
@@ -3,7 +3,7 @@ from typing import Optional
 from lxml import etree
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
-from tei_transform.element_transformation import create_new_element
+from tei_transform.element_transformation import create_new_element, merge_text_content
 
 
 class LonelyCellObserver(AbstractNodeObserver):
@@ -49,8 +49,5 @@ class LonelyCellObserver(AbstractNodeObserver):
                 self._new_table = new_table
                 parent = new_table
         if node.tail is not None and node.tail.strip():
-            if parent.tail is None:
-                parent.tail = node.tail.strip()
-            else:
-                parent.tail += f" {node.tail.strip()}"
+            node.text = merge_text_content(node.text, node.tail)
             node.tail = None

--- a/tei_transform/observer/lonely_row_observer.py
+++ b/tei_transform/observer/lonely_row_observer.py
@@ -3,7 +3,7 @@ from typing import Optional
 from lxml import etree
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
-from tei_transform.element_transformation import create_new_element
+from tei_transform.element_transformation import create_new_element, merge_text_content
 
 
 class LonelyRowObserver(AbstractNodeObserver):
@@ -52,8 +52,5 @@ class LonelyRowObserver(AbstractNodeObserver):
             new_cell = create_new_element(node, "cell")
             node.append(new_cell)
         last_child = node[-1]
-        if last_child.text is None:
-            last_child.text = node.tail.strip()
-        else:
-            last_child.text += f" {node.tail.strip()}"
+        last_child.text = merge_text_content(last_child.text, node.tail)
         node.tail = None

--- a/tei_transform/observer/lonely_row_observer.py
+++ b/tei_transform/observer/lonely_row_observer.py
@@ -14,9 +14,9 @@ class LonelyRowObserver(AbstractNodeObserver):
     and add a new <table/> as parent. Adjacent <row/> elements
     will be added to the same <table/> element. Empty <row/>
     (no children, text, or tail) elements are removed.
-    The tail on the <row/> element is added to the new <table/>
-    parent (N.B.: This might not be valid TEI if the former
-    parent was, for instance, a <div/> element).
+    The tail on the <row/> element is added to the text
+    content of the last <cell/> child if present (otherwise
+    a new <cell/> is added).
     """
 
     def __init__(self) -> None:

--- a/tei_transform/observer/lonely_row_observer.py
+++ b/tei_transform/observer/lonely_row_observer.py
@@ -45,8 +45,15 @@ class LonelyRowObserver(AbstractNodeObserver):
             self._new_table = new_table
         self._new_table.append(node)
         if node.tail is not None and node.tail.strip():
-            if self._new_table.tail is None:
-                self._new_table.tail = node.tail.strip()
-            else:
-                self._new_table.tail += f" {node.tail.strip()}"
-            node.tail = None
+            self._handle_tail(node)
+
+    def _handle_tail(self, node: etree._Element) -> None:
+        if len(node) == 0:
+            new_cell = create_new_element(node, "cell")
+            node.append(new_cell)
+        last_child = node[-1]
+        if last_child.text is None:
+            last_child.text = node.tail.strip()
+        else:
+            last_child.text += f" {node.tail.strip()}"
+        node.tail = None

--- a/tei_transform/observer/lonely_row_observer.py
+++ b/tei_transform/observer/lonely_row_observer.py
@@ -52,5 +52,9 @@ class LonelyRowObserver(AbstractNodeObserver):
             new_cell = create_new_element(node, "cell")
             node.append(new_cell)
         last_child = node[-1]
-        last_child.text = merge_text_content(last_child.text, node.tail)
+        if len(last_child) == 0:
+            last_child.text = merge_text_content(last_child.text, node.tail)
+        else:
+            cell_child = last_child[-1]
+            cell_child.tail = merge_text_content(cell_child.tail, node.tail)
         node.tail = None

--- a/tei_transform/observer/tail_text_observer.py
+++ b/tei_transform/observer/tail_text_observer.py
@@ -8,17 +8,18 @@ class TailTextObserver(AbstractNodeObserver):
     """
     Observer for elements with text in tail.
 
-    Search for elements with tags <p>, <fw> or <ab> that
-    are descendants of <div>, <body>, or <floatingText> and
-    contain text in their tail. The text in the element tail
-    will be removed and added to a new sibling element with
-    tag <p>. If the element has tag <fw> and is a direct descendant
-    of <floatingText>, the tag <fw> will be used instead of <p>.
+    Search for elements with tags <p>, <fw>, <ab>, <list>,
+    or <table> that are descendants of <div>, <body>, or
+    <floatingText> and contain text in their tail. The text
+    in the element tail will be removed and added to a new
+    sibling element with tag <p>. If the element has tag
+    <fw> and is a direct descendant of <floatingText>, the
+    tag <fw> will be used instead of <p>.
     """
 
     def observe(self, node: etree._Element) -> bool:
         node_local_tag = etree.QName(node).localname
-        if node_local_tag in {"p", "ab", "fw"}:
+        if node_local_tag in {"p", "ab", "fw", "list", "table"}:
             parent = node.getparent()
             if parent is not None and etree.QName(parent).localname in {
                 "div",

--- a/tests/test_lonely_cell_observer.py
+++ b/tests/test_lonely_cell_observer.py
@@ -386,3 +386,10 @@ class LonelyCellObserverTester(unittest.TestCase):
         node = root[1]
         self.observer.transform_node(node)
         self.assertTrue(root.find(".//table/row/cell") is not None)
+
+    def test_handling_of_tail_for_cell_with_children(self):
+        root = etree.XML("<p><cell>text<p>inner</p>tail</cell>add</p>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertEqual(node[0].tail, "tail add")
+        self.assertTrue(node.tail is None)

--- a/tests/test_lonely_cell_observer.py
+++ b/tests/test_lonely_cell_observer.py
@@ -328,12 +328,12 @@ class LonelyCellObserverTester(unittest.TestCase):
         result = len(root.findall(".//{*}table/{*}row"))
         self.assertEqual(result, 2)
 
-    def test_tail_added_to_parent(self):
+    def test_tail_added_to_text_content(self):
         root = etree.XML("<div><p><cell>text</cell>tail</p></div>")
         node = root.find(".//cell")
         self.observer.transform_node(node)
-        result = root.find(".//table").tail.strip()
-        self.assertEqual(result, "tail")
+        result = node.text
+        self.assertEqual(result, "text tail")
 
     def test_tail_from_cell_removed(self):
         root = etree.XML("<p><cell>text</cell>tail</p>")
@@ -379,7 +379,7 @@ class LonelyCellObserverTester(unittest.TestCase):
             )
             for node in root.findall(".//table/row")
         ]
-        self.assertEqual(result, [("row", "abc"), ("row", "12"), ("row", "new")])
+        self.assertEqual(result, [("row", "abctail"), ("row", "12"), ("row", "new")])
 
     def test_observer_action_performed_on_cell_with_siblings(self):
         root = etree.XML("<div><p/><cell/><p/></div>")

--- a/tests/test_lonely_row_observer.py
+++ b/tests/test_lonely_row_observer.py
@@ -454,7 +454,7 @@ class LonelyRowObserverTester(unittest.TestCase):
         self.observer.transform_node(node)
         self.assertEqual(len(root.find(".//{*}cell")), 0)
 
-    def test_tail_on_lonely_row_transfered_to_new_table_parent(self):
+    def test_tail_on_lonely_row_last_cell_child(self):
         root = etree.XML(
             """
             <div>
@@ -468,8 +468,8 @@ class LonelyRowObserverTester(unittest.TestCase):
         )
         node = root.find(".//row")
         self.observer.transform_node(node)
-        result = root.find(".//table").tail.strip()
-        self.assertEqual(result, "tail")
+        result = root.find(".//cell").text
+        self.assertEqual(result, "data tail")
 
     def test_tail_removed_from_lonely_row_after_transformation(self):
         root = etree.XML(
@@ -487,30 +487,6 @@ class LonelyRowObserverTester(unittest.TestCase):
         self.observer.transform_node(node)
         result = root.find(".//row").tail
         self.assertEqual(result, None)
-
-    def test_tails_on_multiple_rows_concatenated_and_added_to_table_parent(self):
-        root = etree.XML(
-            """
-            <div>
-              <p>text
-                <row>
-                  <cell>data</cell>
-                </row>a
-                <row>
-                  <cell/>
-                </row>b
-                <row>
-                  <cell/>
-                </row>c
-              </p>
-            </div>
-            """
-        )
-        for node in root.iter():
-            if self.observer.observe(node):
-                self.observer.transform_node(node)
-        result = root.find(".//table").tail
-        self.assertEqual(result, "a b c")
 
     def test_row_without_children_but_with_text_not_removed(self):
         root = etree.XML("<div><row>text</row></div>")
@@ -541,3 +517,9 @@ class LonelyRowObserverTester(unittest.TestCase):
             if self.observer.observe(node):
                 self.observer.transform_node(node)
         self.assertEqual(len(root.findall(".//table")), 3)
+
+    def test_tail_on_empty_row_added_to_new_cell(self):
+        root = etree.XML("<div><p><row/>tail</p></div>")
+        node = root[0][0]
+        self.observer.transform_node(node)
+        self.assertEqual(root.find(".//cell").text, "tail")

--- a/tests/test_lonely_row_observer.py
+++ b/tests/test_lonely_row_observer.py
@@ -523,3 +523,23 @@ class LonelyRowObserverTester(unittest.TestCase):
         node = root[0][0]
         self.observer.transform_node(node)
         self.assertEqual(root.find(".//cell").text, "tail")
+
+    def test_moving_tail_of_row_to_cell_with_children(self):
+        root = etree.XML(
+            """
+            <div>
+              <p>
+                <row>
+                  <cell>text
+                    <p>inner
+                    </p>tail
+                  </cell>
+                </row>target
+              </p>
+            </div>
+            """
+        )
+        node = root.find(".//row")
+        self.observer.transform_node(node)
+        self.assertEqual(root.find(".//row//p").tail, "tail target")
+        self.assertIsNone(node.tail)

--- a/tests/test_tail_text_observer.py
+++ b/tests/test_tail_text_observer.py
@@ -64,6 +64,20 @@ class TailTextObserverTester(unittest.TestCase):
                 </text>
                 """
             ),
+            etree.XML("<div><list/>tail</div>"),
+            etree.XML("<div><table/>tail</div>"),
+            etree.XML("<body><list/>tail</body>"),
+            etree.XML("<body><table/>tail</body>"),
+            etree.XML("<div><table><row><cell>text</cell></row></table>tail</div>"),
+            etree.XML(
+                "<div><div><p>text</p><list><item>text</item></list>tail</div></div>"
+            ),
+            etree.XML("<floatingText><table/>tail</floatingText>"),
+            etree.XML("<floatingText><list/>tail</floatingText>"),
+            etree.XML("<TEI xmlns='a'><body><div><table/>tail</div></body></TEI>"),
+            etree.XML("<TEI xmlns='a'><body><div><list/>tail</div></body></TEI>"),
+            etree.XML("<TEI xmlns='a'><div><div><p/><list/>tail</div></div></TEI>"),
+            etree.XML("<TEI xmlns='a'><body><p/><table/>tail</body></TEI>"),
         ]
         for element in matching_elements:
             result = [self.observer.observe(node) for node in element.iter()]
@@ -182,6 +196,17 @@ class TailTextObserverTester(unittest.TestCase):
                 </text>
                 """
             ),
+            etree.XML("<div><p><table/>tail</p></div>"),
+            etree.XML("<div><p>text<list/>tail</p></div>"),
+            etree.XML("<div><list><item><list/>tail</item></list></div>"),
+            etree.XML("<div><list/></div>"),
+            etree.XML("<div><table/></div>"),
+            etree.XML("<TEI xmlns='a'><body><table/></body></TEI>"),
+            etree.XML(
+                "<TEI xmlns='a'><floatingText><list>text</list></floatingText></TEI>"
+            ),
+            etree.XML("<TEI xmlns='A'><div><p><list/></p><p>text</p></div></TEI>"),
+            etree.XML("<TEI xmlns='a'><div>text<p><table/>tail</p></div></TEI>"),
         ]
         for element in elements:
             result = {self.observer.observe(node) for node in element.iter()}

--- a/tests/test_use_case_impl.py
+++ b/tests/test_use_case_impl.py
@@ -806,6 +806,22 @@ class UseCaseTester(unittest.TestCase):
             with self.subTest():
                 self.assertTrue(result)
 
+    def test_tail_on_list_resolved(self):
+        file = os.path.join(self.data, "file_with_tail_on_list.xml")
+        request = CliRequest(file, ["tail-text"])
+        self.use_case.process(request)
+        _, output = self.xml_writer.assertSingleDocumentWritten()
+        result = self.tei_validator.validate(output)
+        self.assertTrue(result)
+
+    def test_tail_on_table_resolved(self):
+        file = os.path.join(self.data, "file_with_tail_on_table.xml")
+        request = CliRequest(file, ["tail-text"])
+        self.use_case.process(request)
+        _, output = self.xml_writer.assertSingleDocumentWritten()
+        result = self.tei_validator.validate(output)
+        self.assertTrue(result)
+
     def file_invalid_because_classcode_misspelled(self, file):
         logs = self._get_validation_error_logs_for_file(file)
         expected_error_msg = "Did not expect element classcode there"

--- a/tests/testdata/file_with_tail_on_list.xml
+++ b/tests/testdata/file_with_tail_on_list.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <funder>Funder</funder>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <extent>76</extent>
+      <publicationStmt>
+        <publisher>Publisher</publisher>
+        <address>
+          <addrLine>address at city</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+        <authority>
+          <name/>
+        </authority>
+      </publicationStmt>
+      <notesStmt>
+        <note type="source" anchored="true">CD</note>
+        <note type="type">
+          <idno type="date">2022-07-20</idno>
+        </note>
+      </notesStmt>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date type="first">2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="series">Series</idno>
+              <idno type="volume">1</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <editionStmt>
+            <edition>edition</edition>
+          </editionStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date>2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">Series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="bibl">bibl info</idno>
+              <idno type="series">Series</idno>
+              <idno type="page_first">11</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <bibl></bibl>
+        </taxonomy>
+      </classDecl>
+      <projectDesc default="false">
+        <p>Project</p>
+      </projectDesc>
+      <samplingDecl default="false">
+        <p>description how the file was changed</p>
+      </samplingDecl>
+    </encodingDesc>
+    <profileDesc>
+      <textClass default="false">
+        <keywords scheme="#tax">
+          <term n="1" type="main">class</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change>0</change>
+      <change when="2022-07-21"><name>Other Person</name>Change description</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div>
+        <p>
+          <list>
+            <item>text</item>
+            <item/>
+          </list>tail
+        </p>
+        <list>
+          <item/>
+          <item/>
+        </list>tail2
+      <p>text</p>
+    </div>
+    </body>
+  </text>
+</TEI>

--- a/tests/testdata/file_with_tail_on_table.xml
+++ b/tests/testdata/file_with_tail_on_table.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <funder>Funder</funder>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <extent>76</extent>
+      <publicationStmt>
+        <publisher>Publisher</publisher>
+        <address>
+          <addrLine>address at city</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+        <authority>
+          <name/>
+        </authority>
+      </publicationStmt>
+      <notesStmt>
+        <note type="source" anchored="true">CD</note>
+        <note type="type">
+          <idno type="date">2022-07-20</idno>
+        </note>
+      </notesStmt>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date type="first">2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="series">Series</idno>
+              <idno type="volume">1</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <editionStmt>
+            <edition>edition</edition>
+          </editionStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date>2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">Series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="bibl">bibl info</idno>
+              <idno type="series">Series</idno>
+              <idno type="page_first">11</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <bibl></bibl>
+        </taxonomy>
+      </classDecl>
+      <projectDesc default="false">
+        <p>Project</p>
+      </projectDesc>
+      <samplingDecl default="false">
+        <p>description how the file was changed</p>
+      </samplingDecl>
+    </encodingDesc>
+    <profileDesc>
+      <textClass default="false">
+        <keywords scheme="#tax">
+          <term n="1" type="main">class</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change>0</change>
+      <change when="2022-07-21"><name>Other Person</name>Change description</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div>
+        <p>text</p>
+        <table>
+          <row>
+            <cell>text</cell>
+          </row>
+          <row>
+            <cell>text</cell>
+          </row>
+        </table>tail
+    </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
- Add `<list/>` and `<table/>` as target elements to `TailTextObserver`
- `LonelyRowObserver`: Add tails on `<row/>` to last `<cell/>` instead of parent
- `LonelyCellObserver`: Add tail on `<cell/>` to text content instead of parent