### PR TITLE
Add table-text plugin

### DIFF
--- a/Available_plugins.md
+++ b/Available_plugins.md
@@ -75,6 +75,9 @@ Remove ```<relatedItem/>``` elements that do not have children or do not have ``
 ### [schemalocation](observer_docs/schemalocation.md)
 Remove ```@schemaLocation``` attribute from ```<TEI/>``` elements.
 
+### [table-text](observer_docs/table-text.md)
+Remove text content of `<table/>` and tail of children of `<table/>`. Any `<p/>` child of table is converted to `<fw/>`.
+
 ### [tail-text](observer_docs/tail-text.md)
 Remove text in tail of ```<p/>```, ```<ab/>``` and ```<fw/>``` if parent is a ```<div/>```, `<body/>`, or `<floatingText/>`  element. Add a new sibling ```<p/>``` that contains the former tail.
 

--- a/observer_docs/table-text.md
+++ b/observer_docs/table-text.md
@@ -1,0 +1,32 @@
+## table-text
+Remove text content from `<table/>` elements and tail on their children and convert `<p/>` children of `<table/>` to `<fw/>`.
+
+Text content of `<table/>` is added to a new `<head/>` element.
+Tails of elements are concatenated with the text content of the element or, if the tag is `<row/>`, added to the the content of the last `<cell/>` child.  
+
+### Example
+Before transformation:
+```xml
+<table>
+  text
+  <row>
+    <cell>data</cell>
+  </row>tail1
+  <row/>tail2
+  <p>text2</p>
+</table>
+```
+
+After transformation:
+```xml
+<table>
+  <head>text</head>
+  <row>
+    <cell>data tail1</cell>
+  </row>
+  <row>
+    <cell>tail2</cell>
+  </row>
+  <fw>text2</fw>
+</table>
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ p-div-sibling = "tei_transform.observer.p_as_div_sibling_observer:PAsDivSiblingO
 p-head = "tei_transform.observer.head_after_p_element_observer:HeadAfterPElementObserver"
 rel-item = "tei_transform.observer.related_item_observer:RelatedItemObserver"
 schemalocation = "tei_transform.observer.schemalocation_observer:SchemaLocationObserver"
+table-text = "tei_transform.observer.table_text_observer:TableTextObserver"
 tail-text = "tei_transform.observer.tail_text_observer:TailTextObserver"
 teiheader-type = "tei_transform.observer.teiheader_type_observer:TeiHeaderTypeObserver"
 tei-ns = "tei_transform.observer.tei_namespace_observer:TeiNamespaceObserver"

--- a/tei_transform/observer/__init__.py
+++ b/tei_transform/observer/__init__.py
@@ -26,6 +26,7 @@ from tei_transform.observer.notesstmt_observer import NotesStmtObserver
 from tei_transform.observer.p_as_div_sibling_observer import PAsDivSiblingObserver
 from tei_transform.observer.related_item_observer import RelatedItemObserver
 from tei_transform.observer.schemalocation_observer import SchemaLocationObserver
+from tei_transform.observer.table_text_observer import TableTextObserver
 from tei_transform.observer.tail_text_observer import TailTextObserver
 from tei_transform.observer.tei_namespace_observer import TeiNamespaceObserver
 from tei_transform.observer.teiheader_type_observer import TeiHeaderTypeObserver

--- a/tei_transform/observer/table_text_observer.py
+++ b/tei_transform/observer/table_text_observer.py
@@ -1,6 +1,11 @@
 from lxml import etree
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
+from tei_transform.element_transformation import (
+    change_element_tag,
+    create_new_element,
+    merge_text_content,
+)
 
 
 class TableTextObserver(AbstractNodeObserver):
@@ -22,4 +27,30 @@ class TableTextObserver(AbstractNodeObserver):
         return False
 
     def transform_node(self, node: etree._Element) -> None:
-        pass
+        if node.text is not None and node.text.strip():
+            self._handle_text_content_of_table(node)
+        for child in node:
+            child_tag = etree.QName(child).localname
+            if child_tag == "p":
+                change_element_tag(child, "fw")
+            if child.tail is not None and child.tail.strip():
+                if child_tag == "row":
+                    self._add_tail_of_row_to_child(child)
+                else:
+                    if len(child) == 0:
+                        child.text = merge_text_content(child.text, child.tail)
+                    else:
+                        child[-1].tail = merge_text_content(child[-1].tail, child.tail)
+                child.tail = None
+
+    def _add_tail_of_row_to_child(self, subnode: etree._Element) -> None:
+        if len(subnode) == 0:
+            new_cell = create_new_element(subnode, "cell")
+            subnode.append(new_cell)
+        subnode[-1].text = merge_text_content(subnode[-1].text, subnode.tail)
+
+    def _handle_text_content_of_table(self, node: etree._Element) -> None:
+        table_head = create_new_element(node, "head")
+        table_head.text = node.text.strip()
+        node.text = None
+        node.insert(0, table_head)

--- a/tei_transform/observer/table_text_observer.py
+++ b/tei_transform/observer/table_text_observer.py
@@ -11,6 +11,18 @@ from tei_transform.element_transformation import (
 class TableTextObserver(AbstractNodeObserver):
     """
     Observer for <table/> elements that contain text or <p/>.
+
+    Find <table/> elements that contain text, <p/> elements or
+    children with tail.
+
+    The text content of <table/> is added under a new <head/>
+    element as first child of the table.
+
+    Children of <table/> with tag <p/> are converted to <fw/>.
+
+    Tails on children of <table/> are added to the text content,
+    resp. to the text content of the last <cell/> if the tag of
+    the child is <row/>.
     """
 
     def observe(self, node: etree._Element) -> bool:

--- a/tei_transform/observer/table_text_observer.py
+++ b/tei_transform/observer/table_text_observer.py
@@ -1,0 +1,25 @@
+from lxml import etree
+
+from tei_transform.abstract_node_observer import AbstractNodeObserver
+
+
+class TableTextObserver(AbstractNodeObserver):
+    """
+    Observer for <table/> elements that contain text or <p/>.
+    """
+
+    def observe(self, node: etree._Element) -> bool:
+        if etree.QName(node).localname == "table":
+            if node.text is not None and node.text.strip():
+                return True
+            if [
+                child
+                for child in node
+                if (child.tail is not None and child.tail.strip())
+                or etree.QName(child).localname == "p"
+            ] != []:
+                return True
+        return False
+
+    def transform_node(self, node: etree._Element) -> None:
+        pass

--- a/tei_transform/observer/table_text_observer.py
+++ b/tei_transform/observer/table_text_observer.py
@@ -59,7 +59,14 @@ class TableTextObserver(AbstractNodeObserver):
         if len(subnode) == 0:
             new_cell = create_new_element(subnode, "cell")
             subnode.append(new_cell)
-        subnode[-1].text = merge_text_content(subnode[-1].text, subnode.tail)
+        last_cell = subnode[-1]
+        if len(last_cell) == 0:
+            last_cell.text = merge_text_content(last_cell.text, subnode.tail)
+        else:
+            last_child_of_cell = last_cell[-1]
+            last_child_of_cell.tail = merge_text_content(
+                last_child_of_cell.tail, subnode.tail
+            )
 
     def _handle_text_content_of_table(self, node: etree._Element) -> None:
         table_head = create_new_element(node, "head")

--- a/tests/test_table_text_observer.py
+++ b/tests/test_table_text_observer.py
@@ -521,3 +521,22 @@ class TableTextObserverTester(unittest.TestCase):
             if self.observer.observe(node):
                 self.observer.transform_node(node)
         self.assertEqual(len(root.findall(".//p")), 2)
+
+    def test_tail_on_row_with_grandchild_concatenated_with_grandchild_tail(self):
+        root = etree.XML(
+            """
+            <div>
+              <table>
+                <row>
+                  <cell>text
+                    <p>inner</p>tail
+                  </cell>
+                </row>target
+              </table>
+            </div>
+            """
+        )
+        node = root.find(".//table")
+        self.observer.transform_node(node)
+        self.assertEqual(root.find(".//p").tail, "tail target")
+        self.assertIsNone(root.find(".//row").tail)

--- a/tests/test_table_text_observer.py
+++ b/tests/test_table_text_observer.py
@@ -1,0 +1,217 @@
+import unittest
+
+from lxml import etree
+
+from tei_transform.observer import TableTextObserver
+
+
+class TableTextObserverTester(unittest.TestCase):
+    def setUp(self):
+        self.observer = TableTextObserver()
+
+    def test_observer_returns_true_for_matching_element(self):
+        node = etree.XML("<table>text</table>")
+        result = self.observer.observe(node)
+        self.assertTrue(result)
+
+    def test_observer_returns_false_for_non_matching_element(self):
+        root = etree.XML("<div><table><row><cell>text</cell></row></table></div>")
+        node = root[0]
+        result = self.observer.observe(node)
+        self.assertEqual(result, False)
+
+    def test_observer_recognises_matching_elements(self):
+        elements = [
+            etree.XML("<table><row/>tail</table>"),
+            etree.XML("<table><row/><p>text</p></table>"),
+            etree.XML("<div><table>text<row><cell/></row>tail</table></div>"),
+            etree.XML("<div><table><head>text</head>tail<row/></table></div>"),
+            etree.XML("<div><table><row/><p>text</p><row/></table></div>"),
+            etree.XML("<table>text<row><cell>text</cell></row><p/></table>"),
+            etree.XML(
+                """
+                <TEI xmlns='a'>
+                  <div>
+                    <table>text
+                      <row>
+                        <cell>text</cell>
+                      </row>
+                      <row/>
+                    </table>
+                  </div>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='a'>
+                  <div>
+                    <table>
+                      <row>
+                        <cell>text</cell>
+                      </row>tail
+                      <row/>
+                    </table>
+                  </div>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='a'>
+                  <div>
+                    <table>
+                      <row>
+                        <cell>text</cell>
+                      </row>
+                      <p>text</p>
+                      <row/>
+                    </table>
+                  </div>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='a'>
+                  <div>
+                    <table>
+                      <head>text</head>tail
+                      <row>
+                        <cell>text</cell>
+                      </row>
+                      <row/>
+                    </table>
+                  </div>
+                </TEI>
+                """
+            ),
+        ]
+        for element in elements:
+            result = [self.observer.observe(node) for node in element.iter()]
+            with self.subTest():
+                self.assertEqual(sum(result), 1)
+
+    def test_observer_ignores_non_matching_elements(self):
+        elements = [
+            etree.XML("<div><table/>tail</div>"),
+            etree.XML("<table>  <row/></table>"),
+            etree.XML("<div><table><row><cell><p/>tail</cell></row></table></div>"),
+            etree.XML("<table><row/> <row/>\n  </table>"),
+            etree.XML(
+                "<div><table><head>text</head><row><cell/>tail</row></table></div>"
+            ),
+            etree.XML("<table><row/><fw>text</fw><row/></table>"),
+            etree.XML("<table><row><cell><table/>tail</cell></row></table>"),
+            etree.XML("<table><row><cell>text<p>text</p></cell></row></table>"),
+            etree.XML(
+                """
+                <TEI xmlns='a'>
+                  <teiHeader/>
+                  <text>
+                    <div>
+                      <table>
+                        <row>
+                          <cell>text</cell>
+                        </row>
+                      </table>
+                    </div>
+                  </text>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='a'>
+                  <teiHeader/>
+                  <text>
+                    <div>
+                      <table>
+                        <row>
+                          <cell>text
+                            <p>text</p>tail
+                          </cell>
+                        </row>
+                      </table>
+                    </div>
+                  </text>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='a'>
+                  <teiHeader/>
+                  <text>
+                    <div>
+                      <table>
+                        <row>
+                          <cell>text</cell>
+                        </row>
+                      </table>tail
+                    </div>
+                  </text>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='a'>
+                  <teiHeader/>
+                  <text>
+                    <div>
+                      <table>
+                        <head>text</head>
+                        <row>
+                          <cell>text</cell>
+                        </row>
+                      </table>
+                      <p>text</p>
+                    </div>
+                  </text>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='a'>
+                  <teiHeader/>
+                  <text>
+                    <div>
+                      <table>
+                        <row>
+                          <cell>text</cell>
+                        </row>
+                        <fw>text</fw>
+                        <row/>
+                      </table>
+                    </div>
+                  </text>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='a'>
+                  <teiHeader/>
+                  <text>
+                    <div>
+                      <table>
+                        <row>
+                          <cell>text
+                            <table>
+                              <row/>
+                            </table>tail
+                          </cell>
+                        </row>
+                      </table>
+                    </div>
+                  </text>
+                </TEI>
+                """
+            ),
+        ]
+        for element in elements:
+            result = {self.observer.observe(node) for node in element.iter()}
+            with self.subTest():
+                self.assertEqual(result, {False})

--- a/tests/test_use_case_impl.py
+++ b/tests/test_use_case_impl.py
@@ -806,6 +806,14 @@ class UseCaseTester(unittest.TestCase):
             with self.subTest():
                 self.assertTrue(result)
 
+    def test_text_in_table_resolved(self):
+        file = os.path.join(self.data, "file_with_text_in_table.xml")
+        request = CliRequest(file, ["table-text"])
+        self.use_case.process(request)
+        _, output = self.xml_writer.assertSingleDocumentWritten()
+        result = self.tei_validator.validate(output)
+        self.assertTrue(result)
+
     def file_invalid_because_classcode_misspelled(self, file):
         logs = self._get_validation_error_logs_for_file(file)
         expected_error_msg = "Did not expect element classcode there"

--- a/tests/testdata/file_with_text_in_table.xml
+++ b/tests/testdata/file_with_text_in_table.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <funder>Funder</funder>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <extent>76</extent>
+      <publicationStmt>
+        <publisher>Publisher</publisher>
+        <address>
+          <addrLine>address at city</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+        <authority>
+          <name/>
+        </authority>
+      </publicationStmt>
+      <notesStmt>
+        <note type="source" anchored="true">CD</note>
+        <note type="type">
+          <idno type="date">2022-07-20</idno>
+        </note>
+      </notesStmt>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date type="first">2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="series">Series</idno>
+              <idno type="volume">1</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <editionStmt>
+            <edition>edition</edition>
+          </editionStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date>2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">Series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="bibl">bibl info</idno>
+              <idno type="series">Series</idno>
+              <idno type="page_first">11</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <bibl></bibl>
+        </taxonomy>
+      </classDecl>
+      <projectDesc default="false">
+        <p>Project</p>
+      </projectDesc>
+      <samplingDecl default="false">
+        <p>description how the file was changed</p>
+      </samplingDecl>
+    </encodingDesc>
+    <profileDesc>
+      <textClass default="false">
+        <keywords scheme="#tax">
+          <term n="1" type="main">class</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change>0</change>
+      <change when="2022-07-21"><name>Other Person</name>Change description</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div>
+        <table>
+          text
+          <row>
+            <cell>text</cell>
+          </row>tail
+          <row/>tail
+          <p>wrong elem</p>
+          <row>
+            <cell/>
+          </row>tail
+        </table>
+        <p>text</p>
+        <table>
+          <head>text</head>tail
+          <row>
+            <cell/>
+          </row>tail
+        </table>
+      </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
- Handle text content in `<table/>` elements and tail on their children
- Convert `<p/>` to `<fw/>` if parent is `<table/>`