### PR TITLE
Fix removal of empty row

### DIFF
--- a/tei_transform/observer/empty_element_observer.py
+++ b/tei_transform/observer/empty_element_observer.py
@@ -46,9 +46,10 @@ class EmptyElementObserver(AbstractNodeObserver):
             node.tail = None
             node.append(new_cell)
         else:
-            parent.remove(node)
-            if self.observe(parent):
-                self.transform_node(parent)
+            if parent is not None:
+                parent.remove(node)
+                if self.observe(parent):
+                    self.transform_node(parent)
 
     def _handle_list_or_table(
         self, node: etree._Element, parent: etree._Element

--- a/tests/test_empty_element_observer.py
+++ b/tests/test_empty_element_observer.py
@@ -627,3 +627,12 @@ class EmptyElementObserverTester(unittest.TestCase):
         self.assertEqual(
             etree.tostring(root, method="text", encoding="unicode"), "tail"
         )
+
+    def test_transform_empty_element_already_removed_from_tree(self):
+        root = etree.XML("<div><row/><p/></div>")
+        for node in root.iter():
+            if node.tag == "row":
+                node.getparent().remove(node)
+            if self.observer.observe(node):
+                self.observer.transform_node(node)
+        self.assertTrue(root.find(".//row") is None)


### PR DESCRIPTION
Handle removal of empty row that was already removed from tree by other plugin