### PR TITLE
Add option to configure plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,54 +24,61 @@ tei-transform allows command-line usage:
  ```
 ```
 usage: tei-transform [-h] [--transformation TRANSFORMATION [TRANSFORMATION ...]]
-                     [--revision-config REVISION_CONFIG] [--output OUTPUT]
-                     [--no-validation | --copy-valid | --ignore-valid]
+                     [--config-file CONFIG_FILE] [--output OUTPUT]
+                     [--no-validation | --copy-valid | --ignore-valid] [--add-revision]
                      file_or_dir
 
 Parse xml-files that have some errors (that make them invalid according to TEI P5) and apply
 transformations to the file content and save to new file. The old file is not changed. There
-are options to validate files before processing to e.g. ignore valid files. Files are validated
-against the Relax NG scheme of the current version of the TEI guidelines (tei_all.rng).
+are options to validate files before processing to e.g. ignore valid files. Files are
+validated against the Relax NG scheme of the current version of the TEI guidelines
+(tei_all.rng).
 
 positional arguments:
   file_or_dir           File or directory to process
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
   --transformation TRANSFORMATION [TRANSFORMATION ...], -t TRANSFORMATION [TRANSFORMATION ...]
                         Observer plugins that should be used to transform the file content. If
-                        no plugin is passed, the default setting will be used ('schemalocation,
-                        id-attribute, teiheader, notesstmt, filename-element')
-  --revision-config REVISION_CONFIG, -c REVISION_CONFIG
-                        Name of config file where information for change entry for revisionDesc
-                        element in the teiHeader is stored. If no file is passed, no new change
-                        entry will be added to revisionDesc. The file should contain a section
-                        [revision] with the entries 'person = Firstname Lastname', 'reason =
-                        reason why the file was changed' and an optional 'date = YYYY-MM-DD'.
-                        If the person entry should contain multiple names, separate them by
-                        comma. If no date parameter is passed, the current date will be
-                        inserted.
+                        no plugin is passed, the default setting will be used
+                        ('schemalocation, id-attribute, teiheader, notesstmt, filename-
+                        element').
+  --config-file CONFIG_FILE, -c CONFIG_FILE
+                        Name of configuration file. In this file optional configurations for
+                        plugins can be defined as well as the information for the revision
+                        entry. See the documentation of the plugins for available
+                        configurations. The format should be INI.
   --output OUTPUT, -o OUTPUT
-                        Name of output directory to store transformed file in. If the directory
-                        doesn't exist, it will be created. Default is 'output'.
+                        Name of output directory to store transformed file in. If the
+                        directory doesn't exist, it will be created. Default is 'output'.
   --no-validation       Do not validate files before processing. This is the default setting.
                         Valid files will be written to output directory with new timestamp but
-                        without changes to the xml tree. An xml-declaration is added as default
-                        and the formatting of the document may change.
+                        without changes to the xml tree. An xml-declaration is added as
+                        default and the formatting of the document may change.
   --copy-valid          Validate files before processing and copy valid files from input
                         directory to output directory, trying to preserve metadata (i.e.
                         timestamps are preserved, permissions if possible).
   --ignore-valid        Validate files before processing and ignore valid file during
-                        processing. Only transformed files are written to the output directory.
+                        processing. Only transformed files are written to the output
+                        directory.
+  --add-revision, -r    Add an entry to <revisionDesc/> in the header. Default is FALSE. This
+                        option requires the --config-file argument. The config file should
+                        contain a section [revision] with the entries 'person = Firstname
+                        Lastname', 'reason = reason why the file was changed' and an optional
+                        'date = YYYY-MM-DD'. If the person entry should contain multiple
+                        names, separate them by comma. If no date parameter is passed, the
+                        current date will be inserted.
 ```
 
-The **file_or_dir** argument takes the path to the file you want to change.
+The **file_or_dir** argument takes the path to the file or directory of files you want to process.
 
-For all available transformation plugins, see [Available Plugins](Available_plugins.md) .
+For all available transformation plugins, see [Available Plugins](Available_plugins.md). For some plugins, the are configuration options, see docs for usage and options.
 
 If you want to add an entry in the <revisionDesc/> section of the transformed
-document, you can use the keyword argument **revision-config** and pass the name of
-the config file. This file should contain the following section (The date entry is optional.):
+document, you can use the argument **--add-revision** and pass the name of
+the config file with the **--config-file** option. This file should then contain
+the following section (The date entry is optional.):
 
 ```
 [revision]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tei-transform"
-version = "0.0.3"
+version = "0.0.4"
 authors = [{name="Luise Köhler", email="luise.koehler@bbaw.de"}]
 description = "Fix errors in xml document that make it invalid according to TEI P5"
 readme = "README.md"

--- a/tei_transform/cli/controller.py
+++ b/tei_transform/cli/controller.py
@@ -42,18 +42,13 @@ class TeiTransformController:
             ],
         )
         parser.add_argument(
-            "--revision-config",
+            "--config-file",
             "-c",
-            help="""Name of config file where information for change entry for
-            revisionDesc element in the teiHeader is stored. If no file is
-            passed, no new change entry will be added to revisionDesc.
-            The file should contain a section [revision] with the entries 'person =
-            Firstname Lastname', 'reason = reason why the file was changed' and
-            an optional 'date = YYYY-MM-DD'.
-            If the person entry should contain multiple
-            names, separate them by comma. If no date parameter is passed,
-            the current date will be inserted.""",
             default=None,
+            help="""Name of configuration file. In this file optional configurations
+            for plugins can be defined as well as the information for the revision entry.
+            See the documentation of the plugins for available configurations.
+            The format should be INI.""",
         )
         parser.add_argument(
             "--output",
@@ -84,7 +79,21 @@ class TeiTransformController:
             help="""Validate files before processing and ignore valid file during
             processing. Only transformed files are written to the output directory.""",
         )
+        parser.add_argument(
+            "--add-revision",
+            "-r",
+            help="""Add an entry to <revisionDesc/> in the header. Default is FALSE.
+            This option requires the --config-file argument.
+            The config file should contain a section [revision] with the entries
+            'person = Firstname Lastname', 'reason = reason why the file was changed'
+            and an optional 'date = YYYY-MM-DD'.
+            If the person entry should contain multiple names, separate them by
+            comma. If no date parameter is passed, the current date will be inserted.""",
+            action="store_true",
+        )
         args = parser.parse_args(arguments)
+        if args.add_revision and args.config_file is None:
+            parser.error("--add-revision requires --config-file FILENAME")
         validation = not (args.no_validation) and any(
             [args.copy_valid, args.ignore_valid]
         )
@@ -96,9 +105,10 @@ class TeiTransformController:
             CliRequest(
                 file_or_dir=args.file_or_dir,
                 observers=transformation,
-                config=args.revision_config,
+                config=args.config_file,
                 output=args.output,
                 validation=validation,
                 copy_valid=args.copy_valid,
+                add_revision=args.add_revision,
             )
         )

--- a/tei_transform/cli/use_case.py
+++ b/tei_transform/cli/use_case.py
@@ -57,7 +57,9 @@ class TeiTransformationUseCaseImpl:
         self.tei_transformer.set_list_of_observers(observer_lists)
         change = None
         if request.config is not None:
-            change = construct_change_from_config(request.config)
+            config = parse_config_file(request.config)
+        if request.add_revision:
+            change = construct_change_from_config(config)
         if request.validation and self.tei_validator is None:
             self._instantiate_tei_validator()
         if os.path.isfile(request.file_or_dir):

--- a/tei_transform/cli/use_case.py
+++ b/tei_transform/cli/use_case.py
@@ -51,13 +51,14 @@ class TeiTransformationUseCaseImpl:
         Processes cli arguments and applies them to the transformation
         of an xml tree.
         """
+        config = None
+        if request.config is not None:
+            config = parse_config_file(request.config)
         observer_lists = self.observer_constructor.construct_observers(
-            request.observers
+            request.observers, config
         )
         self.tei_transformer.set_list_of_observers(observer_lists)
         change = None
-        if request.config is not None:
-            config = parse_config_file(request.config)
         if request.add_revision:
             change = construct_change_from_config(config)
         if request.validation and self.tei_validator is None:

--- a/tei_transform/cli/use_case.py
+++ b/tei_transform/cli/use_case.py
@@ -7,9 +7,10 @@ from typing import List, Optional, Protocol
 from lxml import etree
 
 from tei_transform.observer_constructor import ObserverConstructor
-from tei_transform.revision_desc_change import (
+from tei_transform.parse_config import (
     RevisionDescChange,
-    construct_change_from_config_file,
+    construct_change_from_config,
+    parse_config_file,
 )
 from tei_transform.tei_transformer import TeiTransformer
 from tei_transform.xml_writer import XmlWriter
@@ -56,7 +57,7 @@ class TeiTransformationUseCaseImpl:
         self.tei_transformer.set_list_of_observers(observer_lists)
         change = None
         if request.config is not None:
-            change = construct_change_from_config_file(request.config)
+            change = construct_change_from_config(request.config)
         if request.validation and self.tei_validator is None:
             self._instantiate_tei_validator()
         if os.path.isfile(request.file_or_dir):

--- a/tei_transform/cli/use_case.py
+++ b/tei_transform/cli/use_case.py
@@ -59,7 +59,7 @@ class TeiTransformationUseCaseImpl:
         )
         self.tei_transformer.set_list_of_observers(observer_lists)
         change = None
-        if request.add_revision:
+        if config is not None and request.add_revision:
             change = construct_change_from_config(config)
         if request.validation and self.tei_validator is None:
             self._instantiate_tei_validator()

--- a/tei_transform/cli/use_case.py
+++ b/tei_transform/cli/use_case.py
@@ -25,6 +25,7 @@ class CliRequest:
     output: str = "output"
     validation: bool = False
     copy_valid: bool = False
+    add_revision: bool = False
 
 
 class TeiTransformationUseCase(Protocol):

--- a/tei_transform/observer_constructor.py
+++ b/tei_transform/observer_constructor.py
@@ -1,5 +1,6 @@
+import configparser
 from importlib import metadata
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
 
@@ -15,16 +16,26 @@ class ObserverConstructor:
         self.plugins_by_name = {plugin.name: plugin for plugin in self.entry_points}
 
     def construct_observers(
-        self, observer_strings: List[str]
+        self,
+        observer_strings: List[str],
+        config: Optional[configparser.ConfigParser] = None,
     ) -> Tuple[List[AbstractNodeObserver], List[AbstractNodeObserver]]:
         first_pass_observers = []
         second_pass_observers = []
         for observer_name in self._sort_plugins(observer_strings):
             observer = self._load_observer(observer_name)
+            if getattr(observer, "config_required", False) and (
+                config is None or observer_name not in config
+            ):
+                raise MissingConfiguration(
+                    f"Configuration required for {observer_name} plugin."
+                )
             if not self._is_valid_observer(observer):
                 raise InvalidObserver(
                     f"{observer_name} is not an instance of AbstractNodeObserver."
                 )
+            if config is not None:
+                self._configure_observer(observer, config, observer_name)
             if observer_name in {"p-div-sibling", "div-sibling"}:
                 second_pass_observers.append(observer)
                 continue
@@ -49,6 +60,19 @@ class ObserverConstructor:
     def _move_div_parent_to_front(self, observer_strings: List[str]) -> List[str]:
         return sorted(observer_strings, key=lambda x: x == "div-parent", reverse=True)
 
+    def _configure_observer(
+        self,
+        observer: AbstractNodeObserver,
+        config: configparser.ConfigParser,
+        plugin_name: str,
+    ) -> None:
+        if hasattr(observer, "configure"):
+            observer.configure(config[plugin_name])
+
 
 class InvalidObserver(Exception):
+    pass
+
+
+class MissingConfiguration(Exception):
     pass

--- a/tei_transform/parse_config.py
+++ b/tei_transform/parse_config.py
@@ -15,18 +15,24 @@ class RevisionDescChange:
 logger = logging.getLogger(__name__)
 
 
-def construct_change_from_config_file(file: str) -> Optional[RevisionDescChange]:
+def parse_config_file(file: str) -> configparser.ConfigParser:
+    config = configparser.ConfigParser()
+    config.read(file)
+    return config
+
+
+def construct_change_from_config(
+    config: configparser.ConfigParser,
+) -> Optional[RevisionDescChange]:
     """
-    Read config file and extract data from [revision] section,
-    where the information for the change is stored.
+    Extract data from [revision] section in config, where the information
+    for the change is stored.
     Return a RevisionDescChange with the gathered information.
     In the config file, the [revision] section should specify a 'person'
     responsible for the change and a 'reason' how the file was changed. An
     optional 'date' can also be indicated. If 'date' is missing, the current
     date will be used.
     """
-    config = configparser.ConfigParser()
-    config.read(file)
     if "revision" not in config.sections():
         logger.warning("No section [revision] found in config file.")
         return None

--- a/tei_transform/tei_transformer.py
+++ b/tei_transform/tei_transformer.py
@@ -6,7 +6,7 @@ from lxml import etree
 from tei_transform.abstract_node_observer import AbstractNodeObserver
 from tei_transform.element_transformation import construct_new_tei_root
 from tei_transform.observer import TeiNamespaceObserver
-from tei_transform.revision_desc_change import RevisionDescChange
+from tei_transform.parse_config import RevisionDescChange
 from tei_transform.xml_tree_iterator import XMLTreeIterator
 
 logger = logging.getLogger(__name__)

--- a/tests/mock_observer.py
+++ b/tests/mock_observer.py
@@ -10,11 +10,14 @@ class MockConfigurableObserver(AbstractNodeObserver):
         self.configurable = True
         self.attribute = attribute
 
-    def observe(self, node: etree._Element) -> None:
-        pass
+    def observe(self, node: etree._Element) -> bool:
+        if etree.QName(node).localname == "target":
+            return True
+        return False
 
-    def transform_node(self, node):
-        pass
+    def transform_node(self, node: etree._Element) -> None:
+        if self.attribute is not None:
+            node.set("attribute", self.attribute)
 
     def configure(self, config):
         allowed_actions = {"setattr": setattr}

--- a/tests/mock_observer.py
+++ b/tests/mock_observer.py
@@ -1,0 +1,44 @@
+from importlib import metadata
+
+from lxml import etree
+
+from tei_transform.abstract_node_observer import AbstractNodeObserver
+
+
+class MockConfigurableObserver(AbstractNodeObserver):
+    def __init__(self, attribute=None):
+        self.configurable = True
+        self.attribute = attribute
+
+    def observe(self, node: etree._Element) -> None:
+        pass
+
+    def transform_node(self, node):
+        pass
+
+    def configure(self, config):
+        allowed_actions = {"setattr": setattr}
+        action = config["action"]
+        if action in allowed_actions:
+            allowed_actions[action](self, "attribute", config["attribute"])
+
+
+class MockObserverConfigRequired(AbstractNodeObserver):
+    def __init__(self, attribute=None):
+        self.config_required = True
+
+    def observe(self):
+        pass
+
+    def transform_node(self, node):
+        pass
+
+
+def add_mock_plugin_entry_point(observer_constructor, plugin_name, plugin_path):
+    mock_entry_point = metadata.EntryPoint(
+        name=plugin_name,
+        value=plugin_path,
+        group="node_observer",
+    )
+    observer_constructor.entry_points += mock_entry_point
+    observer_constructor.plugins_by_name[plugin_name] = mock_entry_point

--- a/tests/test_cli_interface.py
+++ b/tests/test_cli_interface.py
@@ -40,6 +40,7 @@ def test_run_with_config_file():
                 tmp_conf,
                 "-o",
                 tempdir,
+                "-r",
             ],
             capture_output=True,
         )

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -48,7 +48,7 @@ class TeiTransformControllerTester(unittest.TestCase):
         )
 
     def test_controller_extracts_config_file_name(self):
-        self.controller.process_arguments(["file.xml", "--revision-config", "config"])
+        self.controller.process_arguments(["file.xml", "--config-file", "config"])
         self.assertEqual(self.mock_use_case.request.config, "config")
 
     def test_controller_extracts_config_file_name_with_kw(self):
@@ -105,3 +105,19 @@ class TeiTransformControllerTester(unittest.TestCase):
         ):
             with self.assertRaises(SystemExit):
                 self.controller.process_arguments(["file", opt1, opt2])
+
+    def test_revision_argument_requires_config_file(self):
+        with self.assertRaises(SystemExit):
+            self.controller.process_arguments(["file", "--revision"])
+
+    def test_revision_argument_requires_config_file_with_flag(self):
+        with self.assertRaises(SystemExit):
+            self.controller.process_arguments(["file", "-r"])
+
+    def test_controller_extracts_revision_default_false(self):
+        self.controller.process_arguments(["file", "-c", "conf-file"])
+        self.assertEqual(self.mock_use_case.request.add_revision, False)
+
+    def test_controller_extracts_revision(self):
+        self.controller.process_arguments(["file", "-r", "-c", "conf_file"])
+        self.assertEqual(self.mock_use_case.request.add_revision, True)

--- a/tests/test_observer_constructor.py
+++ b/tests/test_observer_constructor.py
@@ -17,6 +17,7 @@ from tei_transform.observer_constructor import (
     ObserverConstructor,
 )
 from tei_transform.parse_config import parse_config_file
+from tests.mock_observer import add_mock_plugin_entry_point
 
 
 class ObserverConstructorTester(unittest.TestCase):
@@ -140,7 +141,7 @@ class ObserverConstructorTester(unittest.TestCase):
         add_mock_plugin_entry_point(
             constructor,
             "mock",
-            "tests.test_observer_constructor:MockConfigurableObserver",
+            "tests.mock_observer:MockConfigurableObserver",
         )
         test_observer = constructor.construct_observers(["mock"], config)[0][0]
         self.assertEqual(test_observer.attribute, "some value")
@@ -151,7 +152,7 @@ class ObserverConstructorTester(unittest.TestCase):
         add_mock_plugin_entry_point(
             constructor,
             "mock",
-            "tests.test_observer_constructor:MockObserverConfigRequired",
+            "tests.mock_observer:MockObserverConfigRequired",
         )
         with self.assertRaises(MissingConfiguration):
             constructor.construct_observers(["mock"], config)
@@ -161,7 +162,7 @@ class ObserverConstructorTester(unittest.TestCase):
         add_mock_plugin_entry_point(
             constructor,
             "mock",
-            "tests.test_observer_constructor:MockObserverConfigRequired",
+            "tests.mock_observer:MockObserverConfigRequired",
         )
         with self.assertRaises(MissingConfiguration):
             constructor.construct_observers(["mock"])
@@ -171,7 +172,7 @@ class ObserverConstructorTester(unittest.TestCase):
         add_mock_plugin_entry_point(
             constructor,
             "mock",
-            "tests.test_observer_constructor:MockConfigurableObserver",
+            "tests.mock_observer:MockConfigurableObserver",
         )
         test_observer = constructor.construct_observers(["mock"])[0][0]
         self.assertIsNone(test_observer.attribute)
@@ -181,7 +182,7 @@ class ObserverConstructorTester(unittest.TestCase):
         add_mock_plugin_entry_point(
             constructor,
             "mock",
-            "tests.test_observer_constructor:MockConfigurableObserver",
+            "tests.mock_observer:MockConfigurableObserver",
         )
         config = parse_config_file(os.path.join(self.cfg_dir, "mock.cfg"))
         observers = constructor.construct_observers(
@@ -195,7 +196,7 @@ class ObserverConstructorTester(unittest.TestCase):
         add_mock_plugin_entry_point(
             constructor,
             "mock",
-            "tests.test_observer_constructor:MockConfigurableObserver",
+            "tests.mock_observer:MockConfigurableObserver",
         )
         config = parse_config_file(os.path.join(self.cfg_dir, "mock.cfg"))
         observers = constructor.construct_observers(["mock"], config)
@@ -208,42 +209,3 @@ class ObserverConstructorTester(unittest.TestCase):
             ["filename-element"], config
         )[0][0]
         self.assertTrue(isinstance(test_observer, FilenameElementObserver))
-
-
-class MockConfigurableObserver(AbstractNodeObserver):
-    def __init__(self, attribute=None):
-        self.configurable = True
-        self.attribute = attribute
-
-    def observe(self):
-        pass
-
-    def transform_node(self, node):
-        pass
-
-    def configure(self, config):
-        allowed_actions = {"setattr": setattr}
-        action = config["action"]
-        if action in allowed_actions:
-            allowed_actions[action](self, "attribute", config["attribute"])
-
-
-class MockObserverConfigRequired(AbstractNodeObserver):
-    def __init__(self, attribute=None):
-        self.config_required = True
-
-    def observe(self):
-        pass
-
-    def transform_node(self, node):
-        pass
-
-
-def add_mock_plugin_entry_point(observer_constructor, plugin_name, plugin_path):
-    mock_entry_point = metadata.EntryPoint(
-        name=plugin_name,
-        value=plugin_path,
-        group="node_observer",
-    )
-    observer_constructor.entry_points += mock_entry_point
-    observer_constructor.plugins_by_name[plugin_name] = mock_entry_point

--- a/tests/test_observer_constructor.py
+++ b/tests/test_observer_constructor.py
@@ -1,3 +1,4 @@
+import os
 import random
 import unittest
 from importlib import metadata
@@ -10,12 +11,18 @@ from tei_transform.observer import (
     FilenameElementObserver,
     PAsDivSiblingObserver,
 )
-from tei_transform.observer_constructor import InvalidObserver, ObserverConstructor
+from tei_transform.observer_constructor import (
+    InvalidObserver,
+    MissingConfiguration,
+    ObserverConstructor,
+)
+from tei_transform.parse_config import parse_config_file
 
 
 class ObserverConstructorTester(unittest.TestCase):
     def setUp(self):
         self.constructor = ObserverConstructor()
+        self.cfg_dir = os.path.join("tests", "testdata", "conf_files")
 
     def test_observer_construction(self):
         test_observer = self.constructor.construct_observers(["filename-element"])[0][0]
@@ -126,3 +133,119 @@ class ObserverConstructorTester(unittest.TestCase):
             _, second_pass = self.constructor.construct_observers(plugins_to_use)
             with self.subTest():
                 self.assertEqual([], second_pass)
+
+    def test_observer_initialized_with_configuration(self):
+        constructor = ObserverConstructor()
+        config = parse_config_file(os.path.join(self.cfg_dir, "config"))
+        mock_entry_point = metadata.EntryPoint(
+            name="mock",
+            value="tests.test_observer_constructor:MockConfigurableObserver",
+            group="node_observer",
+        )
+        constructor.entry_points += mock_entry_point
+        constructor.plugins_by_name["mock"] = mock_entry_point
+        test_observer = constructor.construct_observers(["mock"], config)[0][0]
+        self.assertEqual(test_observer.attribute, "some value")
+
+    def test_error_raised_if_observer_requires_config_but_missing(self):
+        config = parse_config_file(os.path.join(self.cfg_dir, "filename.cfg"))
+        constructor = ObserverConstructor()
+        mock_entry_point = metadata.EntryPoint(
+            name="mock",
+            value="tests.test_observer_constructor:MockObserverConfigRequired",
+            group="node_observer",
+        )
+        constructor.entry_points += mock_entry_point
+        constructor.plugins_by_name["mock"] = mock_entry_point
+        with self.assertRaises(MissingConfiguration):
+            constructor.construct_observers(["mock"], config)
+
+    def test_error_raised_if_observer_requires_config_but_no_config_passed(self):
+        constructor = ObserverConstructor()
+        mock_entry_point = metadata.EntryPoint(
+            name="mock",
+            value="tests.test_observer_constructor:MockObserverConfigRequired",
+            group="node_observer",
+        )
+        constructor.entry_points += mock_entry_point
+        constructor.plugins_by_name["mock"] = mock_entry_point
+        with self.assertRaises(MissingConfiguration):
+            constructor.construct_observers(["mock"])
+
+    def test_construction_of_observer_with_optional_config_if_no_config_passed(self):
+        constructor = ObserverConstructor()
+        mock_entry_point = metadata.EntryPoint(
+            name="mock",
+            value="tests.test_observer_constructor:MockConfigurableObserver",
+            group="node_observer",
+        )
+        constructor.entry_points += mock_entry_point
+        constructor.plugins_by_name["mock"] = mock_entry_point
+        test_observer = constructor.construct_observers(["mock"])[0][0]
+        self.assertIsNone(test_observer.attribute)
+
+    def test_config_only_added_to_matching_observer(self):
+        constructor = ObserverConstructor()
+        mock_entry_point = metadata.EntryPoint(
+            name="mock",
+            value="tests.test_observer_constructor:MockConfigurableObserver",
+            group="node_observer",
+        )
+        constructor.entry_points += mock_entry_point
+        constructor.plugins_by_name["mock"] = mock_entry_point
+        config = parse_config_file(os.path.join(self.cfg_dir, "mock.cfg"))
+        observers = constructor.construct_observers(
+            ["mock", "filename-element"], config
+        )
+        test_observer = observers[0][1]
+        self.assertEqual(hasattr(test_observer, "attribute"), False)
+
+    def test_unnecessary_config_ignored(self):
+        constructor = ObserverConstructor()
+        mock_entry_point = metadata.EntryPoint(
+            name="mock",
+            value="tests.test_observer_constructor:MockConfigurableObserver",
+            group="node_observer",
+        )
+        constructor.entry_points += mock_entry_point
+        constructor.plugins_by_name["mock"] = mock_entry_point
+        config = parse_config_file(os.path.join(self.cfg_dir, "mock.cfg"))
+        observers = constructor.construct_observers(["mock"], config)
+        mock_observer = observers[0][0]
+        self.assertEqual(mock_observer.attribute, "value")
+
+    def test_config_for_non_configurable_observer_ignored(self):
+        config = parse_config_file(os.path.join(self.cfg_dir, "filename.cfg"))
+        test_observer = self.constructor.construct_observers(
+            ["filename-element"], config
+        )[0][0]
+        self.assertTrue(isinstance(test_observer, FilenameElementObserver))
+
+
+class MockConfigurableObserver(AbstractNodeObserver):
+    def __init__(self, attribute=None):
+        self.configurable = True
+        self.attribute = attribute
+
+    def observe(self):
+        pass
+
+    def transform_node(self, node):
+        pass
+
+    def configure(self, config):
+        allowed_actions = {"setattr": setattr}
+        action = config["action"]
+        if action in allowed_actions:
+            allowed_actions[action](self, "attribute", config["attribute"])
+
+
+class MockObserverConfigRequired(AbstractNodeObserver):
+    def __init__(self, attribute=None):
+        self.config_required = True
+
+    def observe(self):
+        pass
+
+    def transform_node(self, node):
+        pass

--- a/tests/test_observer_constructor.py
+++ b/tests/test_observer_constructor.py
@@ -197,8 +197,8 @@ class ObserverConstructorTester(unittest.TestCase):
         observers = constructor.construct_observers(
             ["mock", "filename-element"], config
         )
-        test_observer = observers[0][1]
-        self.assertEqual(hasattr(test_observer, "attribute"), False)
+        self.assertEqual(hasattr(observers[0][1], "attribute"), False)
+        self.assertEqual(observers[0][0].attribute, "value")
 
     def test_unnecessary_config_ignored(self):
         constructor = ObserverConstructor()

--- a/tests/test_observer_constructor.py
+++ b/tests/test_observer_constructor.py
@@ -137,62 +137,52 @@ class ObserverConstructorTester(unittest.TestCase):
     def test_observer_initialized_with_configuration(self):
         constructor = ObserverConstructor()
         config = parse_config_file(os.path.join(self.cfg_dir, "config"))
-        mock_entry_point = metadata.EntryPoint(
-            name="mock",
-            value="tests.test_observer_constructor:MockConfigurableObserver",
-            group="node_observer",
+        add_mock_plugin_entry_point(
+            constructor,
+            "mock",
+            "tests.test_observer_constructor:MockConfigurableObserver",
         )
-        constructor.entry_points += mock_entry_point
-        constructor.plugins_by_name["mock"] = mock_entry_point
         test_observer = constructor.construct_observers(["mock"], config)[0][0]
         self.assertEqual(test_observer.attribute, "some value")
 
     def test_error_raised_if_observer_requires_config_but_missing(self):
         config = parse_config_file(os.path.join(self.cfg_dir, "filename.cfg"))
         constructor = ObserverConstructor()
-        mock_entry_point = metadata.EntryPoint(
-            name="mock",
-            value="tests.test_observer_constructor:MockObserverConfigRequired",
-            group="node_observer",
+        add_mock_plugin_entry_point(
+            constructor,
+            "mock",
+            "tests.test_observer_constructor:MockObserverConfigRequired",
         )
-        constructor.entry_points += mock_entry_point
-        constructor.plugins_by_name["mock"] = mock_entry_point
         with self.assertRaises(MissingConfiguration):
             constructor.construct_observers(["mock"], config)
 
     def test_error_raised_if_observer_requires_config_but_no_config_passed(self):
         constructor = ObserverConstructor()
-        mock_entry_point = metadata.EntryPoint(
-            name="mock",
-            value="tests.test_observer_constructor:MockObserverConfigRequired",
-            group="node_observer",
+        add_mock_plugin_entry_point(
+            constructor,
+            "mock",
+            "tests.test_observer_constructor:MockObserverConfigRequired",
         )
-        constructor.entry_points += mock_entry_point
-        constructor.plugins_by_name["mock"] = mock_entry_point
         with self.assertRaises(MissingConfiguration):
             constructor.construct_observers(["mock"])
 
     def test_construction_of_observer_with_optional_config_if_no_config_passed(self):
         constructor = ObserverConstructor()
-        mock_entry_point = metadata.EntryPoint(
-            name="mock",
-            value="tests.test_observer_constructor:MockConfigurableObserver",
-            group="node_observer",
+        add_mock_plugin_entry_point(
+            constructor,
+            "mock",
+            "tests.test_observer_constructor:MockConfigurableObserver",
         )
-        constructor.entry_points += mock_entry_point
-        constructor.plugins_by_name["mock"] = mock_entry_point
         test_observer = constructor.construct_observers(["mock"])[0][0]
         self.assertIsNone(test_observer.attribute)
 
     def test_config_only_added_to_matching_observer(self):
         constructor = ObserverConstructor()
-        mock_entry_point = metadata.EntryPoint(
-            name="mock",
-            value="tests.test_observer_constructor:MockConfigurableObserver",
-            group="node_observer",
+        add_mock_plugin_entry_point(
+            constructor,
+            "mock",
+            "tests.test_observer_constructor:MockConfigurableObserver",
         )
-        constructor.entry_points += mock_entry_point
-        constructor.plugins_by_name["mock"] = mock_entry_point
         config = parse_config_file(os.path.join(self.cfg_dir, "mock.cfg"))
         observers = constructor.construct_observers(
             ["mock", "filename-element"], config
@@ -202,13 +192,11 @@ class ObserverConstructorTester(unittest.TestCase):
 
     def test_unnecessary_config_ignored(self):
         constructor = ObserverConstructor()
-        mock_entry_point = metadata.EntryPoint(
-            name="mock",
-            value="tests.test_observer_constructor:MockConfigurableObserver",
-            group="node_observer",
+        add_mock_plugin_entry_point(
+            constructor,
+            "mock",
+            "tests.test_observer_constructor:MockConfigurableObserver",
         )
-        constructor.entry_points += mock_entry_point
-        constructor.plugins_by_name["mock"] = mock_entry_point
         config = parse_config_file(os.path.join(self.cfg_dir, "mock.cfg"))
         observers = constructor.construct_observers(["mock"], config)
         mock_observer = observers[0][0]
@@ -249,3 +237,13 @@ class MockObserverConfigRequired(AbstractNodeObserver):
 
     def transform_node(self, node):
         pass
+
+
+def add_mock_plugin_entry_point(observer_constructor, plugin_name, plugin_path):
+    mock_entry_point = metadata.EntryPoint(
+        name=plugin_name,
+        value=plugin_path,
+        group="node_observer",
+    )
+    observer_constructor.entry_points += mock_entry_point
+    observer_constructor.plugins_by_name[plugin_name] = mock_entry_point

--- a/tests/test_parse_config.py
+++ b/tests/test_parse_config.py
@@ -2,16 +2,16 @@ import datetime
 import os
 import tempfile
 
-from tei_transform.revision_desc_change import (
+from tei_transform.parse_config import (
     RevisionDescChange,
-    construct_change_from_config_file,
+    construct_change_from_config,
+    parse_config_file,
 )
 
 
-def test_data_parsed_correctly_from_config_file():
-    change = construct_change_from_config_file(
-        os.path.join("tests", "testdata", "revision.config")
-    )
+def test_revision_data_parsed_correctly_from_config_file():
+    config = parse_config_file(os.path.join("tests", "testdata", "revision.config"))
+    change = construct_change_from_config(config)
     expected_change = RevisionDescChange(
         person=["Some Name"],
         date="2022-05-23",
@@ -29,7 +29,8 @@ def test_current_date_inserted_when_not_defined():
         _, tmp_conf = tempfile.mkstemp(".ini", dir=tempdir, text=True)
         with open(tmp_conf, "w") as ptr:
             ptr.write(conf_string)
-        change = construct_change_from_config_file(tmp_conf)
+        config = parse_config_file(tmp_conf)
+        change = construct_change_from_config(config)
     assert change.date == datetime.date.today().isoformat()
 
 
@@ -42,11 +43,12 @@ def test_multiple_person_names_parsed_correctly():
         _, tmp_conf = tempfile.mkstemp(".ini", dir=tempdir, text=True)
         with open(tmp_conf, "w") as ptr:
             ptr.write(conf_string)
-        change = construct_change_from_config_file(tmp_conf)
+        config = parse_config_file(tmp_conf)
+        change = construct_change_from_config(config)
     assert change.person == ["First Name", "Second Name"]
 
 
-def test_malformed_config_file_returns_none():
+def test_malformed_revision_entry_returns_none():
     conf_string = """
 [revisionDesc]
 person = Person Name
@@ -55,7 +57,8 @@ reason = Some reason"""
         _, tmp_conf = tempfile.mkstemp(".ini", dir=tempdir, text=True)
         with open(tmp_conf, "w") as ptr:
             ptr.write(conf_string)
-        change = construct_change_from_config_file(tmp_conf)
+        config = parse_config_file(tmp_conf)
+        change = construct_change_from_config(config)
     assert change is None
 
 
@@ -67,7 +70,8 @@ def test_none_inserted_for_missing_reason():
         _, tmp_conf = tempfile.mkstemp(".ini", dir=tempdir, text=True)
         with open(tmp_conf, "w") as ptr:
             ptr.write(conf_string)
-        change = construct_change_from_config_file(tmp_conf)
+        config = parse_config_file(tmp_conf)
+        change = construct_change_from_config(config)
     assert change.reason is None
 
 
@@ -79,5 +83,24 @@ def test_empty_list_returned_for_missing_person():
         _, tmp_conf = tempfile.mkstemp(".ini", dir=tempdir, text=True)
         with open(tmp_conf, "w") as ptr:
             ptr.write(conf_string)
-        change = construct_change_from_config_file(tmp_conf)
+        config = parse_config_file(tmp_conf)
+        change = construct_change_from_config(config)
     assert change.person == []
+
+
+def test_config_file_parsed():
+    conf_string = """
+    [sectionA]
+    attribute=someAttribute
+    [sectionB]
+    key=value
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        _, tmp_cfg = tempfile.mkstemp(".ini", dir=tempdir, text=True)
+        with open(tmp_cfg, "w") as fh:
+            fh.write(conf_string)
+        config = parse_config_file(tmp_cfg)
+        assert "sectionA" in config.keys()
+        assert "sectionB" in config.keys()
+        assert config["sectionA"]["attribute"] == "someAttribute"
+        assert config["sectionB"]["key"] == "value"

--- a/tests/test_tei_transformer.py
+++ b/tests/test_tei_transformer.py
@@ -4,7 +4,7 @@ import unittest
 from lxml import etree
 
 from tei_transform.observer import TeiNamespaceObserver
-from tei_transform.revision_desc_change import RevisionDescChange
+from tei_transform.parse_config import RevisionDescChange
 from tei_transform.tei_transformer import TeiTransformer
 from tei_transform.xml_tree_iterator import XMLTreeIterator
 

--- a/tests/test_use_case_impl.py
+++ b/tests/test_use_case_impl.py
@@ -869,7 +869,7 @@ class UseCaseTester(unittest.TestCase):
         )
         self.assertTrue(result)
 
-    def test_neste_table_and_list_in_fw_resolved(self):
+    def test_nested_table_and_list_in_fw_resolved(self):
         result = self._validate_file_processed_with_plugins(
             "file_with_table_in_fw.xml", ["fw-child", "nested-fw"]
         )

--- a/tests/test_use_case_impl.py
+++ b/tests/test_use_case_impl.py
@@ -165,16 +165,20 @@ class UseCaseTester(unittest.TestCase):
                 "schemalocation",
             ],
             config=conf_file,
+            add_revision=True,
         )
         self.use_case.process(request)
         _, output = self.xml_writer.assertSingleDocumentWritten()
         result = self.tei_validator.validate(output)
+        self.assertEqual(len(output.find(".//{*}revisionDesc")), 3)
         self.assertTrue(result)
 
     def test_revision_change_added(self):
         file = os.path.join(self.data, "file_with_id_in_tei.xml")
         conf_file = os.path.join(self.data, "revision.config")
-        request = CliRequest(file, ["teiheader-type"], config=conf_file)
+        request = CliRequest(
+            file, ["teiheader-type"], config=conf_file, add_revision=True
+        )
         self.use_case.process(request)
         _, result_tree = self.xml_writer.assertSingleDocumentWritten()
         revision_node = result_tree.find(".//{*}revisionDesc")
@@ -244,6 +248,7 @@ class UseCaseTester(unittest.TestCase):
                 "schemalocation",
             ],
             config=conf_file,
+            add_revision=True,
         )
         self.use_case.process(request)
         _, output = self.xml_writer.assertSingleDocumentWritten()
@@ -646,7 +651,11 @@ class UseCaseTester(unittest.TestCase):
         input_dir = os.path.join(self.data, "dir_with_subdir_and_valid_files")
         conf_file = os.path.join(self.data, "revision.config")
         request = CliRequest(
-            input_dir, ["byline-sibling"], validation=False, config=conf_file
+            input_dir,
+            ["byline-sibling"],
+            validation=False,
+            config=conf_file,
+            add_revision=True,
         )
         self.use_case.process(request)
         result = sorted(

--- a/tests/testdata/conf_files/config
+++ b/tests/testdata/conf_files/config
@@ -1,0 +1,3 @@
+[mock]
+action=setattr
+attribute=some value

--- a/tests/testdata/conf_files/filename.cfg
+++ b/tests/testdata/conf_files/filename.cfg
@@ -1,0 +1,2 @@
+[filename-element]
+key=value

--- a/tests/testdata/conf_files/mock.cfg
+++ b/tests/testdata/conf_files/mock.cfg
@@ -1,0 +1,11 @@
+[mock]
+action=setattr
+attribute=value
+
+[filename-element]
+action=set_attribute
+attribute=value1
+
+[div-parent]
+action=set_attribute
+attribute=value2

--- a/tests/testdata/file_with_target_to_configure.xml
+++ b/tests/testdata/file_with_target_to_configure.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <funder>Funder</funder>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <extent>76</extent>
+      <publicationStmt>
+        <publisher>Publisher</publisher>
+        <address>
+          <addrLine>address at city</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+        <authority>
+          <name/>
+        </authority>
+      </publicationStmt>
+      <notesStmt>
+        <note type="source" anchored="true">CD</note>
+        <note type="type">
+          <idno type="date">2022-07-20</idno>
+        </note>
+      </notesStmt>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date type="first">2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="series">Series</idno>
+              <idno type="volume">1</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author>Name</author>
+          </titleStmt>
+          <editionStmt>
+            <edition>edition</edition>
+          </editionStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date>2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">Series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="bibl">bibl info</idno>
+              <idno type="series">Series</idno>
+              <idno type="page_first">11</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <bibl></bibl>
+        </taxonomy>
+      </classDecl>
+      <projectDesc default="false">
+        <p>Project</p>
+      </projectDesc>
+      <samplingDecl default="false">
+        <p>description how the file was changed</p>
+      </samplingDecl>
+    </encodingDesc>
+    <profileDesc>
+      <textClass default="false">
+        <keywords scheme="#tax">
+          <term n="1" type="main">class</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change>0</change>
+      <change when="2022-07-21"><name>Other Person</name>Change description</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div>
+        <p>text</p>
+        <target>here!</target>
+      </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
- added option to pass general config file via CLI
- changed command line argument for revision-config name and type to bolean
- added handling of configuration of plugins to ObserverConstructor