### PR TITLE
Update byline-sibling

### DIFF
--- a/tei_transform/observer/byline_sibling_observer.py
+++ b/tei_transform/observer/byline_sibling_observer.py
@@ -38,25 +38,25 @@ class BylineSiblingObserver(AbstractNodeObserver):
     ]
 
     def observe(self, node: etree._Element) -> bool:
-        if list(node.itersiblings("{*}byline", preceding=True)):
+        byline_siblings = list(node.itersiblings("{*}byline", preceding=True))
+        if byline_siblings != []:
             if etree.QName(node).localname not in self.div_wrapper + self.head_like:
-                parent = node.getparent()
-                byline_sibling = parent.find("{*}byline")
-                siblings_before_invalid_tags = [
-                    etree.QName(sibling).localname
-                    not in self.head_like + self.div_wrapper
-                    for sibling in byline_sibling.itersiblings(preceding=True)
-                ]
-                if siblings_before_invalid_tags:
-                    siblings_after_invalid_tags = [
-                        etree.QName(sibling).localname not in self.div_wrapper
-                        for sibling in byline_sibling.itersiblings(preceding=False)
+                for byline_element in byline_siblings:
+                    siblings_before_invalid_tags = [
+                        etree.QName(sibling).localname
+                        not in self.head_like + self.div_wrapper
+                        for sibling in byline_element.itersiblings(preceding=True)
                     ]
-                    if siblings_after_invalid_tags:
-                        if any(siblings_after_invalid_tags) and any(
-                            siblings_before_invalid_tags
-                        ):
-                            return True
+                    if siblings_before_invalid_tags:
+                        siblings_after_invalid_tags = [
+                            etree.QName(sibling).localname not in self.div_wrapper
+                            for sibling in byline_element.itersiblings(preceding=False)
+                        ]
+                        if siblings_after_invalid_tags:
+                            if any(siblings_after_invalid_tags) and any(
+                                siblings_before_invalid_tags
+                            ):
+                                return True
         return False
 
     def transform_node(self, node: etree._Element) -> None:

--- a/tei_transform/observer/byline_sibling_observer.py
+++ b/tei_transform/observer/byline_sibling_observer.py
@@ -31,6 +31,7 @@ class BylineSiblingObserver(AbstractNodeObserver):
         "signed",
         "meeting",
         "salute",
+        "figure",
     ]
     head_like = [
         "head",

--- a/tests/test_byline_sibling_observer.py
+++ b/tests/test_byline_sibling_observer.py
@@ -92,6 +92,8 @@ class BylineSiblingObserverTester(unittest.TestCase):
             etree.XML("<div><p/><byline/><signed/></div>"),
             etree.XML("<div><p/><byline/><meeting/></div>"),
             etree.XML("<div><p/><byline/><salute/></div>"),
+            etree.XML("<div><p/><byline/><figure/></div>"),
+            etree.XML("<div><figure/><byline/><p/></div>"),
         ]
         for element in elements:
             result = {self.observer.observe(node) for node in element.iter()}

--- a/tests/test_use_case_impl.py
+++ b/tests/test_use_case_impl.py
@@ -933,6 +933,12 @@ class UseCaseTester(unittest.TestCase):
         )
         self.assertTrue(result)
 
+    def test_byline_with_figure(self):
+        result = self._validate_file_processed_with_plugins(
+            "file_with_byline_and_figure.xml", ["byline-sibling", "p-div-sibling"]
+        )
+        self.assertTrue(result)
+
     def file_invalid_because_classcode_misspelled(self, file):
         logs = self._get_validation_error_logs_for_file(file)
         expected_error_msg = "Did not expect element classcode there"

--- a/tests/testdata/file_with_byline_and_figure.xml
+++ b/tests/testdata/file_with_byline_and_figure.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <funder>Funder</funder>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <extent>76</extent>
+      <publicationStmt>
+        <publisher>Publisher</publisher>
+        <address>
+          <addrLine>address at city</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+        <authority>
+          <name/>
+        </authority>
+      </publicationStmt>
+      <notesStmt>
+        <note type="source" anchored="true">CD</note>
+        <note type="type">
+          <idno type="date">2022-07-20</idno>
+        </note>
+      </notesStmt>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date type="first">2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="series">Series</idno>
+              <idno type="volume">1</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <editionStmt>
+            <edition>edition</edition>
+          </editionStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date>2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">Series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="bibl">bibl info</idno>
+              <idno type="series">Series</idno>
+              <idno type="page_first">11</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <bibl></bibl>
+        </taxonomy>
+      </classDecl>
+      <projectDesc default="false">
+        <p>Project</p>
+      </projectDesc>
+      <samplingDecl default="false">
+        <p>description how the file was changed</p>
+      </samplingDecl>
+    </encodingDesc>
+    <profileDesc>
+      <textClass default="false">
+        <keywords scheme="#tax">
+          <term n="1" type="main">class</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change>0</change>
+      <change when="2022-07-21"><name>Other Person</name>Change description</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div>
+        <p>text</p>
+        <byline>byline text</byline>
+        <figure/>
+        <p/>
+    </div>
+    <div>
+      <figure/>
+            <byline>byline text</byline>
+            <p>text</p>
+            <p/>
+        </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
- Added `<figure/>` to tags allowed after `<byline/>`.
- Changed element identification to fix bug for target elements with multiple `<byline/>` sibling where the first sibling had valid siblings and thus the target was not correctly identified.