### PR TITLE
Update TailTextObserver to handle unicode whitespace chars

### DIFF
--- a/tei_transform/observer/tail_text_observer.py
+++ b/tei_transform/observer/tail_text_observer.py
@@ -36,7 +36,7 @@ class TailTextObserver(AbstractNodeObserver):
         if node.tail.strip():
             self._handle_real_text_tail(node)
         else:
-            self._substitue_whitespace_chars(node)
+            self._substitute_whitespace_chars(node)
 
     def _handle_real_text_tail(self, node: etree._Element) -> None:
         tail_text = node.tail
@@ -51,5 +51,5 @@ class TailTextObserver(AbstractNodeObserver):
         node.tail = None
         node.addnext(new_elem)
 
-    def _substitue_whitespace_chars(self, node: etree._Element) -> None:
+    def _substitute_whitespace_chars(self, node: etree._Element) -> None:
         node.tail = re.sub(r"\s", " ", node.tail)

--- a/tests/test_tail_text_observer.py
+++ b/tests/test_tail_text_observer.py
@@ -296,3 +296,20 @@ class TailTextObserverTester(unittest.TestCase):
         node = root.find(".//{*}fw")
         self.observer.transform_node(node)
         self.assertEqual(node.getnext().tail, None)
+
+    def test_tail_with_unicode_whitespace_cleaned(self):
+        root = etree.XML(
+            """
+        <div>
+            <p>text1</p>   \xa0
+            <p>text2</p>\n\n
+            <p>text3</p>    \t
+            <p>text4</p>\u2028
+        </div>"""
+        )
+        for node in root.iter():
+            if self.observer.observe(node):
+                self.observer.transform_node(node)
+        result = [child.tail.strip(" ") for child in root]
+        self.assertEqual(["", "\n\n\n", "\t\n", ""], result)
+        self.assertEqual(len(root), 4)

--- a/tests/test_use_case_impl.py
+++ b/tests/test_use_case_impl.py
@@ -1018,6 +1018,12 @@ class UseCaseTester(unittest.TestCase):
         )
         self.assertTrue(result)
 
+    def test_unicode_whitespace_characters_removed(self):
+        result = self._validate_file_processed_with_plugins(
+            "file_with_unicode_whitespace.xml", ["tail-text"]
+        )
+        self.assertTrue(result)
+
     def file_invalid_because_classcode_misspelled(self, file):
         logs = self._get_validation_error_logs_for_file(file)
         expected_error_msg = "Did not expect element classcode there"

--- a/tests/testdata/file_with_unicode_whitespace.xml
+++ b/tests/testdata/file_with_unicode_whitespace.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <funder>Funder</funder>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <extent>76</extent>
+      <publicationStmt>
+        <publisher>Publisher</publisher>
+        <address>
+          <addrLine>address at city</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+        <authority>
+          <name/>
+        </authority>
+      </publicationStmt>
+      <notesStmt>
+        <note type="source" anchored="true">CD</note>
+        <note type="type">
+          <idno type="date">2022-07-20</idno>
+        </note>
+      </notesStmt>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date type="first">2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="series">Series</idno>
+              <idno type="volume">1</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author>Name</author>
+          </titleStmt>
+          <editionStmt>
+            <edition>edition</edition>
+          </editionStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date>2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">Series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="bibl">bibl info</idno>
+              <idno type="series">Series</idno>
+              <idno type="page_first">11</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <bibl></bibl>
+        </taxonomy>
+      </classDecl>
+      <projectDesc default="false">
+        <p>Project</p>
+      </projectDesc>
+      <samplingDecl default="false">
+        <p>description how the file was changed</p>
+      </samplingDecl>
+    </encodingDesc>
+    <profileDesc>
+      <textClass default="false">
+        <keywords scheme="#tax">
+          <term n="1" type="main">class</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change>0</change>
+      <change when="2022-07-21"><name>Other Person</name>Change description</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <p>text<lb/>text1</p>
+ <p>text2</p>
+<p>text</p>
+    <p>text</p>
+    <p/> 
+      <p>text</p>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
Substitute all whitespace chars with " " in tails containing only whitespace to avoid files with unicode whitespace chars in tails (which are treated as text content by some validators).