### PR TITLE
Update ListTextObserver to handle <lb/>

### DIFF
--- a/observer_docs/list-text.md
+++ b/observer_docs/list-text.md
@@ -1,7 +1,7 @@
 ## list-text
 Remove text from ```<list/>``` elements and add under new ```<item/>```.
 
-Find ```<list/>``` elements that contain text or any `<item/>` elements with tail. The text content of `<list/>` is added under a new ```<item/>``` element. Any text content in tails on `<item/>` children of the `<list/>` are concatenated with the text content of the `<item/>` (resp. added to the tail of the last child if `<item/>`, if present).
+Find ```<list/>``` elements that contain text or any elements with tail. The text content of `<list/>` is added under a new ```<item/>``` element. Any text content in tails on `<item/>` or other children of the `<list/>` are concatenated with the text content of the `<item/>` (resp. added to the tail of the last child if `<item/>`, if present). If the child has `<lb/>` tag, it is appended to its previous sibling.
 
 ### Example
 Before transformation:
@@ -9,6 +9,10 @@ Before transformation:
 <div>
   <list>
     text
+  </list>
+  <list>
+    text
+    <lb/>text2
   </list>
   <list>
     <item>text</item>tail
@@ -24,6 +28,9 @@ After transformation:
 <div>
   <list>
     <item>text</item>
+  </list>
+  <list>
+    <item>text<lb/>text2</item>
   </list>
   <list>
     <item>text tail</item>

--- a/tei_transform/observer/list_text_observer.py
+++ b/tei_transform/observer/list_text_observer.py
@@ -28,9 +28,16 @@ class ListTextObserver(AbstractNodeObserver):
     def transform_node(self, node: etree._Element) -> None:
         if node.text is not None and node.text.strip():
             self._remove_text_content_from_list(node)
-        for child in node.iterchildren("{*}item"):
-            if child.tail is not None and child.tail.strip():
+        for child in node.iterchildren():
+            if (
+                etree.QName(child).localname == "item"
+                and child.tail is not None
+                and child.tail.strip()
+            ):
                 self._remove_tail_from_item_child(child)
+            if etree.QName(child).localname == "lb":
+                prev_sibling = child.getprevious()
+                prev_sibling.append(child)
 
     def _remove_text_content_from_list(self, node: etree._Element) -> None:
         new_item = create_new_element(node, "item")

--- a/tei_transform/observer/list_text_observer.py
+++ b/tei_transform/observer/list_text_observer.py
@@ -1,7 +1,11 @@
 from lxml import etree
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
-from tei_transform.element_transformation import create_new_element, merge_text_content
+from tei_transform.element_transformation import (
+    change_element_tag,
+    create_new_element,
+    merge_text_content,
+)
 
 
 class ListTextObserver(AbstractNodeObserver):
@@ -38,8 +42,7 @@ class ListTextObserver(AbstractNodeObserver):
             ):
                 self._remove_tail_from_item_child(child)
             if etree.QName(child).localname == "lb":
-                prev_sibling = child.getprevious()
-                prev_sibling.append(child)
+                self._handle_lb_child(node, child)
 
     def _remove_text_content_from_list(self, node: etree._Element) -> None:
         new_item = create_new_element(node, "item")
@@ -54,3 +57,11 @@ class ListTextObserver(AbstractNodeObserver):
         else:
             item_child.text = merge_text_content(item_child.text, item_child.tail)
         item_child.tail = None
+
+    def _handle_lb_child(self, node: etree._Element, lb_child: etree._Element) -> None:
+        prev_sibling = lb_child.getprevious()
+        if prev_sibling is None:
+            change_element_tag(lb_child, "item")
+            lb_child.text, lb_child.tail = lb_child.tail, None
+            return
+        prev_sibling.append(lb_child)

--- a/tei_transform/observer/list_text_observer.py
+++ b/tei_transform/observer/list_text_observer.py
@@ -12,6 +12,8 @@ class ListTextObserver(AbstractNodeObserver):
     under a new <item/> element or have any <item/> elements
     with tail as children and concatenate the tail with the
     text content of the <item/>.
+    If the <list/> contains <lb/> elements, the <lb/> is
+    appended to its previous sibling.
     """
 
     def observe(self, node: etree._Element) -> bool:

--- a/tests/test_list_text_observer.py
+++ b/tests/test_list_text_observer.py
@@ -501,3 +501,21 @@ class ListTextObserverTester(unittest.TestCase):
         self.assertEqual(target.text, "text tail1")
         self.assertEqual(target[0].tag, "lb")
         self.assertEqual(target[0].tail, "tail2")
+
+    def test_lb_as_first_child_with_only_whitespace_text_before(self):
+        root = etree.XML("<div><list>    \n<lb/>tail</list></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertIsNone(root.find(".//list/lb"))
+
+    def test_tail_removed_if_lb_converted_to_item(self):
+        root = etree.XML("<div><list>    \n<lb/>tail<item/></list></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertIsNone(node[0].tail)
+
+    def test_tail_added_as_text_if_lb_converted_to_item(self):
+        root = etree.XML("<div><list>    \n<lb/>tail</list></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertEqual(node[0].text, "tail")

--- a/tests/test_list_text_observer.py
+++ b/tests/test_list_text_observer.py
@@ -466,3 +466,21 @@ class ListTextObserverTester(unittest.TestCase):
         root = etree.XML("<list><item>text</item>tail</list>")
         self.observer.transform_node(root)
         self.assertEqual(root[0].text, "text tail")
+
+    def test_lb_child_added_to_previous_sibling_with_only_text(self):
+        root = etree.XML("<div><list>text<lb/>tail</list></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//item/lb") is not None)
+
+    def test_lb_child_added_to_previous_sibling_with_previous_sibling(self):
+        root = etree.XML("<div><list><item>text</item><lb/>tail</list></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//item/lb") is not None)
+
+    def test_lb_child_added_to_previous_sibling_with_following_sibling(self):
+        root = etree.XML("<div><list>text<lb/>tail<item>text2</item>tail</list></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertEqual(node[-1].text, "text2 tail")

--- a/tests/test_list_text_observer.py
+++ b/tests/test_list_text_observer.py
@@ -477,13 +477,14 @@ class ListTextObserverTester(unittest.TestCase):
         root = etree.XML("<div><list><item>text</item><lb/>tail</list></div>")
         node = root[0]
         self.observer.transform_node(node)
-        self.assertTrue(root.find(".//item/lb") is not None)
+        self.assertEqual(root.find(".//item")[0].tag, "lb")
 
     def test_lb_child_added_to_previous_sibling_with_following_sibling(self):
         root = etree.XML("<div><list>text<lb/>tail<item>text2</item>tail</list></div>")
         node = root[0]
         self.observer.transform_node(node)
-        self.assertEqual(node[-1].text, "text2 tail")
+        self.assertEqual(len(root.findall(".//item")), 2)
+        self.assertEqual(root.find(".//item")[0].tag, "lb")
 
     def test_adding_lb_to_sibling_with_child(self):
         root = etree.XML("<div><list><item><p>text</p></item><lb/>tail</list></div>")

--- a/tests/test_list_text_observer.py
+++ b/tests/test_list_text_observer.py
@@ -484,3 +484,19 @@ class ListTextObserverTester(unittest.TestCase):
         node = root[0]
         self.observer.transform_node(node)
         self.assertEqual(node[-1].text, "text2 tail")
+
+    def test_adding_lb_to_sibling_with_child(self):
+        root = etree.XML("<div><list><item><p>text</p></item><lb/>tail</list></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        result = [child.tag for child in root.find(".//item")]
+        self.assertEqual(result, ["p", "lb"])
+
+    def test_adding_lb_to_sibling_with_child_and_tail(self):
+        root = etree.XML("<div><list><item>text</item>tail1<lb/>tail2</list></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        target = root.find(".//item")
+        self.assertEqual(target.text, "text tail1")
+        self.assertEqual(target[0].tag, "lb")
+        self.assertEqual(target[0].tail, "tail2")

--- a/tests/testdata/file_with_text_in_list.xml
+++ b/tests/testdata/file_with_text_in_list.xml
@@ -122,6 +122,7 @@
         <list>text3
           <item>text4</item>tail4
         </list>
+        <list> text <lb/>more text</list>
     </div>
     </body>
   </text>


### PR DESCRIPTION
Update `ListTextObserver` /*list-text* : If `<list/>` contains `<lb/>` elements, add it to previous sibling.