### PR TITLE
Update CodeElementObserver

### DIFF
--- a/Available_plugins.md
+++ b/Available_plugins.md
@@ -18,8 +18,7 @@ N.B.: The invalid element that was the former direct sibling of ```<byline/>``` 
 Replace ```<classcode/>``` elements with ```<classCode/>```.
 
 ### [code-elem](observer_docs/code-elem.md)
-Replace `<code/>` elements with `<ab/>` if the element has descendants or is a descendant of `<div/>`. N.B.: Use in combination with *double-plike* plugin to avoid nesting of `<ab/>`
- and `<p/>` elements.
+Replace `<code/>` elements with `<ab/>` if the element has descendants and set `@type='code'` attribute. If the parent has `<p/>` or `<ab/>` tag, the former `<code/>` element is added as sibling of the parent.
 
 ### [div-parent](observer_docs/div-parent.md)
 Strip `<div/>` elements with invalid parents. If the parent of `<div/>` is `<p/>` or `<ab/>`, the `<div/>` element is added as a sibling of its parent.

--- a/observer_docs/code-elem.md
+++ b/observer_docs/code-elem.md
@@ -1,16 +1,23 @@
 ## code-elem
-Find  `<code/>` elements that have children or that are direct descendants of `<div/>` elements and change their tag to `<ab/>`.
-N.B.: Use in combination with *double-plike* plugin to avoid nesting of `<p/>` and `<ab/>`.
+Find  `<code/>` elements that have children and change their tag to `<ab/>` and set `@type='code'` attribute If the `@type` attribute is already present, it won't be overwritten.
+If the `<code/>` element has `@lang` attribute, it is removed and its value is concatenated with the `@type` attribute (only if it was newly set to `code`).
+If the parent of the `<code/>` element has tag `<p/>` or `<ab/>`, the `<code/>` element is added as next sibling of its parent during the transformation. Any following siblings are added as children are appended to a new element with the tag of the parent which is added next to the `<code/>` element.
+
+
 
 ### Example
 Before transformation:
 ```xml
 <div>
-  <code>abc</code>
-  <p>
+  <code lang='python'>
+    for i in range(10):<lb/>
+        print(i)
+  </code>
+  <p>text
     <code>
-      <hi>text</hi>
+      <hi>text1</hi>
     </code>
+    <list/>
   </p>
 </div>
 ```
@@ -18,12 +25,16 @@ Before transformation:
 After transformation:
 ```xml
 <div>
-  <ab>abc</ab>
+  <ab type="code-python">
+    for i in range(10):<lb/>
+        print(i)
+  </ab>
+  <p>text</p>
+  <ab type="code">
+    <hi>text1</hi>
+  </ab>
   <p>
-    <!-- use double-plike to avoid this invalid structure -->
-    <ab>
-      <hi>text</hi>
-    </ab>
+    <list/>
   </p>
 </div>
 ```

--- a/tei_transform/observer/code_element_observer.py
+++ b/tei_transform/observer/code_element_observer.py
@@ -6,22 +6,21 @@ from tei_transform.element_transformation import change_element_tag
 
 class CodeElementObserver(AbstractNodeObserver):
     """
-    Observer for <code/> elements that have descendants or <div/>
-    as parent.
+    Observer for <code/> elements that have descendants.
 
     Find <code/> elements that have other elements as descendants
-    or are themselves directly descending from a <div/> element
-    and change their tag to <ab/>.
-    N.B.: This might result in a non-valid TEI document, if
-    the parent of the former <code/> element was, for instance,
-    a <p/> or <ab/> element. Use in combination with DoublePlikeObserver
-    to avoid invalid nesting of <p/>-like elements.
+    and change their tag to <ab/> and set @type='code' attribute.
+    If the parent of <code/> has tag </p> or <ab/>, the <code/>
+    element is added as next sibling of its parent.
+    If the <code/> element has following siblings, a new element
+    with the same tag as the parent is added as next to
+    the former <code/> element and the sibling elements are
+    added to this new element.
     """
 
     def observe(self, node: etree._Element) -> bool:
-        if etree.QName(node).localname == "code":
-            if len(node) != 0 or etree.QName(node.getparent()).localname == "div":
-                return True
+        if etree.QName(node).localname == "code" and len(node) != 0:
+            return True
         return False
 
     def transform_node(self, node: etree._Element) -> None:

--- a/tei_transform/observer/code_element_observer.py
+++ b/tei_transform/observer/code_element_observer.py
@@ -1,7 +1,10 @@
 from lxml import etree
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
-from tei_transform.element_transformation import change_element_tag
+from tei_transform.element_transformation import (
+    change_element_tag,
+    remove_attribute_from_node,
+)
 
 
 class CodeElementObserver(AbstractNodeObserver):
@@ -10,6 +13,9 @@ class CodeElementObserver(AbstractNodeObserver):
 
     Find <code/> elements that have other elements as descendants
     and change their tag to <ab/> and set @type='code' attribute.
+    If the <code/> element has @lang attribute, the attribute is
+    removed and the value concatenated with the type attribute
+    (if it was newly added).
     If the parent of <code/> has tag </p> or <ab/>, the <code/>
     element is added as next sibling of its parent.
     If the <code/> element has following siblings, a new element
@@ -25,3 +31,9 @@ class CodeElementObserver(AbstractNodeObserver):
 
     def transform_node(self, node: etree._Element) -> None:
         change_element_tag(node, "ab")
+        if node.attrib.get("type", None) is None:
+            type_attr_value = "code"
+            if (lang_value := node.attrib.get("lang", None)) is not None:
+                type_attr_value = f"{type_attr_value}-{lang_value}"
+            node.set("type", type_attr_value)
+        remove_attribute_from_node(node, "lang")

--- a/tei_transform/observer/code_element_observer.py
+++ b/tei_transform/observer/code_element_observer.py
@@ -4,6 +4,7 @@ from tei_transform.abstract_node_observer import AbstractNodeObserver
 from tei_transform.element_transformation import (
     change_element_tag,
     remove_attribute_from_node,
+    create_new_element,
 )
 
 
@@ -37,3 +38,14 @@ class CodeElementObserver(AbstractNodeObserver):
                 type_attr_value = f"{type_attr_value}-{lang_value}"
             node.set("type", type_attr_value)
         remove_attribute_from_node(node, "lang")
+        parent = node.getparent()
+        parent_tag = etree.QName(parent).localname
+        if parent_tag in {"p", "ab"}:
+            grand_parent = parent.getparent()
+            parent_index = grand_parent.index(parent)
+            following_siblings = list(node.itersiblings())
+            if following_siblings:
+                new_parent = create_new_element(node, parent_tag)
+                grand_parent.insert(parent_index + 1, new_parent)
+                new_parent.extend(following_siblings)
+            grand_parent.insert(parent_index + 1, node)

--- a/tests/test_code_element_observer.py
+++ b/tests/test_code_element_observer.py
@@ -23,16 +23,18 @@ class CodeElementObserverTester(unittest.TestCase):
 
     def test_observer_recognises_matching_elements(self):
         elements = [
-            etree.XML("<div><code/></div>"),
-            etree.XML("<div><code>text</code></div>"),
+            etree.XML("<div><code>a<lb/>b</code></div>"),
+            etree.XML("<div><code>text<hi>text</hi></code></div>"),
             etree.XML("<div><p>text<code>text<lb/>text</code></p></div>"),
             etree.XML("<div><p><code>text<p/></code></p></div>"),
-            etree.XML("<div><div><code>text</code></div></div>"),
+            etree.XML("<div><div><code>text<lb/>text2</code></div></div>"),
             etree.XML("<body><div><p>text<code><p>text</p></code></p></div></body>"),
             etree.XML("<p><code><ab>text</ab></code></p>"),
             etree.XML("<p><code><list/></code></p>"),
-            etree.XML("<TEI xmlns='ns'><div><code/></div></TEI>"),
-            etree.XML("<TEI xmlns='ns'><div><code>text</code></div></TEI>"),
+            etree.XML("<TEI xmlns='ns'><div><code>a<lb/>b</code></div></TEI>"),
+            etree.XML(
+                "<TEI xmlns='ns'><div><code>text<list/>text<lb/></code></div></TEI>"
+            ),
             etree.XML("<TEI xmlns='ns'><div><p>text<code><p/></code></p></div></TEI>"),
             etree.XML(
                 "<TEI xmlns='ns'><div><p><code><ab>text</ab>tail</code>tail</p></div></TEI>"
@@ -61,6 +63,8 @@ class CodeElementObserverTester(unittest.TestCase):
 
     def test_observer_ignores_non_matching_elements(self):
         elements = [
+            etree.XML("<div><code/></div>"),
+            etree.XML("<div><code>text</code></div>"),
             etree.XML("<div><p><code>abc</code></p></div>"),
             etree.XML("<quote>text<lb/><code>abc</code><lb/>text</quote>"),
             etree.XML("<p>a<hi>b<code>c</code>d</hi>e</p>"),
@@ -69,6 +73,7 @@ class CodeElementObserverTester(unittest.TestCase):
             etree.XML("<div><fw>text<code/>tail</fw></div>"),
             etree.XML("<div><p>text<code>ab</code>text</p></div>"),
             etree.XML("<body><div><ab><code/></ab></div></body>"),
+            etree.XML("<body><p/><code>text</code></body>"),
             etree.XML(
                 "<TEI xmlns='ns'><body><div><p><code>text</code></p></div></body></TEI>"
             ),
@@ -78,23 +83,12 @@ class CodeElementObserverTester(unittest.TestCase):
             etree.XML(
                 "<TEI xmlns='ns'><div><list><item><code>text</code></item></list></div></TEI>"
             ),
+            etree.XML("<TEI xmlns='ns'><div><code>text</code></div></TEI>"),
         ]
         for element in elements:
             result = {self.observer.observe(node) for node in element.iter()}
             with self.subTest():
                 self.assertEqual(result, {False})
-
-    def test_tag_converted_to_ab_if_div_parent(self):
-        root = etree.XML("<div><code>abc</code></div>")
-        node = root[0]
-        self.observer.transform_node(node)
-        self.assertTrue(root.find("./ab") is not None)
-
-    def test_tag_converted_to_ab_if_div_parent_with_namespace(self):
-        root = etree.XML("<TEI xmlns='ns'><div><code>text</code></div></TEI>")
-        node = root.find(".//{*}code")
-        self.observer.transform_node(node)
-        self.assertTrue(root.find(".//{*}ab") is not None)
 
     def test_tag_converted_to_ab_for_element_with_children(self):
         root = etree.XML("<div><p>text<code>text<hi>text</hi></code></p></div>")

--- a/tests/testdata/file_with_wrong_code_elem.xml
+++ b/tests/testdata/file_with_wrong_code_elem.xml
@@ -113,7 +113,7 @@
     <body>
       <div>
         <p>text</p>
-        <code>text1</code>
+        <code>text1<lb/>ttext</code>
         <code>
           <hi>text</hi>
         </code>


### PR DESCRIPTION
- Changed element identification to only activate on `<code/>` elements with children
- Added some attribute handling 
- Added hierarchy resolution if parent is `<p/>` or `<ab/>`