### PR TITLE
Add head-parent plugin

### DIFF
--- a/Available_plugins.md
+++ b/Available_plugins.md
@@ -63,6 +63,9 @@ Remove ```<filename/>``` elements.
 ### [fw-child](observer_docs/fw-child.md)
 Find `<p/>`, `<list/>`, and `<table/>` elements with `<fw/>` parent. Merge `<p/>` element into parent. Rename parent to `<ab/>` if target has tag `<list/>` or `<table/>`.
 
+### [head-parent](observer_docs/head-parent.md)
+Change tag of `<head/>` elements with wrong parent (`<p/>`, `<ab/>`, `<hi/>`, `<head/>`, `<item/>`) to `<hi/>`.
+
 ### [head-type](observer_docs/head-type.md)
 Remove ```@type``` attribute from ```<head/>``` elements.
 

--- a/observer_docs/head-parent.md
+++ b/observer_docs/head-parent.md
@@ -1,0 +1,31 @@
+## head-parent
+Change tag of `<head/>` elements that are children of `<p/>`, `<ab/>`, `<hi/>`, `<head/>`, or `<item/>` to `<hi/>`.
+
+### Example
+Before transformation:
+```xml
+<div>
+  <p>text1<head>text2</head></p>
+  <list>
+    <item>
+      <head>text3
+        <head>text4</head>
+      </head>
+    </item>
+  </list>
+</div>
+```
+
+After transformation:
+```xml
+<div>
+  <p>text1<hi>text2</hi></p>
+  <list>
+    <item>
+      <hi>text3
+        <hi>text4</hi>
+      </hi>
+    </item>
+  </list>
+</div>
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ empty-scheme = "tei_transform.observer.scheme_attribute_observer:SchemeAttribute
 empty-stmt = "tei_transform.observer.empty_stmt_observer:EmptyStmtObserver"
 filename-element = "tei_transform.observer.filename_element_observer:FilenameElementObserver"
 fw-child = "tei_transform.observer.fw_child_observer:FwChildObserver"
+head-parent = "tei_transform.observer.head_parent_observer:HeadParentObserver"
 head-type = "tei_transform.observer.head_with_type_attr_observer:HeadWithTypeAttrObserver"
 hi-child = "tei_transform.observer.hi_child_observer:HiChildObserver"
 hi-parent = "tei_transform.observer.hi_with_wrong_parent_observer:HiWithWrongParentObserver"

--- a/tei_transform/observer/__init__.py
+++ b/tei_transform/observer/__init__.py
@@ -20,6 +20,7 @@ from tei_transform.observer.fw_child_observer import FwChildObserver
 from tei_transform.observer.head_after_p_element_observer import (
     HeadAfterPElementObserver,
 )
+from tei_transform.observer.head_parent_observer import HeadParentObserver
 from tei_transform.observer.head_with_type_attr_observer import HeadWithTypeAttrObserver
 from tei_transform.observer.hi_child_observer import HiChildObserver
 from tei_transform.observer.hi_with_wrong_parent_observer import (

--- a/tei_transform/observer/head_parent_observer.py
+++ b/tei_transform/observer/head_parent_observer.py
@@ -1,12 +1,15 @@
 from lxml import etree
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
+from tei_transform.element_transformation import change_element_tag
 
 
 class HeadParentObserver(AbstractNodeObserver):
     """
-    Observer for <head/> elements with <p/>, <ab/>, <head/>, <hi/>
-    or <item/> parent.
+    Observer for <head/> elements with wrong parent.
+
+    Find <head/> elements that have <p/>, <ab/>, <head/>, <hi/> or
+    <item/> as parent and change their tag to <hi/>.
     """
 
     def observe(self, node: etree._Element) -> bool:
@@ -17,4 +20,4 @@ class HeadParentObserver(AbstractNodeObserver):
         return False
 
     def transform_node(self, node: etree._Element) -> None:
-        pass
+        change_element_tag(node, "hi")

--- a/tei_transform/observer/head_parent_observer.py
+++ b/tei_transform/observer/head_parent_observer.py
@@ -1,0 +1,20 @@
+from lxml import etree
+
+from tei_transform.abstract_node_observer import AbstractNodeObserver
+
+
+class HeadParentObserver(AbstractNodeObserver):
+    """
+    Observer for <head/> elements with <p/>, <ab/>, <head/>, <hi/>
+    or <item/> parent.
+    """
+
+    def observe(self, node: etree._Element) -> bool:
+        if etree.QName(node).localname == "head":
+            parent = node.getparent()
+            if etree.QName(parent).localname in {"p", "ab", "head", "hi", "item"}:
+                return True
+        return False
+
+    def transform_node(self, node: etree._Element) -> None:
+        pass

--- a/tests/test_head_parent_observer.py
+++ b/tests/test_head_parent_observer.py
@@ -1,0 +1,70 @@
+import unittest
+
+from lxml import etree
+
+from tei_transform.observer import HeadParentObserver
+
+
+class HeadParentObserverTester(unittest.TestCase):
+    def setUp(self):
+        self.observer = HeadParentObserver()
+
+    def test_observer_returns_true_for_matching_element(self):
+        root = etree.XML("<item><head>text</head></item>")
+        node = root[0]
+        result = self.observer.observe(node)
+        self.assertTrue(result)
+
+    def test_observer_returns_false_for_non_matching_element(self):
+        root = etree.XML("<div><head>text</head></div>")
+        node = root[0]
+        result = self.observer.observe(node)
+        self.assertEqual(result, False)
+
+    def test_observer_recognises_matching_elements(self):
+        elements = [
+            etree.XML("<p>text<head>text2</head></p>"),
+            etree.XML("<ab>text<head>text2</head>text3</ab>"),
+            etree.XML("<div><head>text<head>text2</head></head></div>"),
+            etree.XML(
+                "<div><list><item><head rendition='i'>text</head></item></list></div>"
+            ),
+            etree.XML(
+                "<body><head/><p/><ab type='sth'>text<head rendition='a'>text2</head>text</ab></body>"
+            ),
+            etree.XML("<div><p>text<hi>ab<head>cd</head>text</hi></p></div>"),
+            etree.XML("<div><p/><head>a<head/>b</head>c</div>"),
+            etree.XML("<TEI xmlns='a'><div><p>a<list/><head/>b<p/></p></div></TEI>"),
+            etree.XML("<TEI xmlns='a'><div><ab>text<head/></ab></div></TEI>"),
+            etree.XML(
+                "<TEI xmlsn='a'><div><list><item>a<head/>b</item></list></div></TEI>"
+            ),
+            etree.XML(
+                "<TEI xmlns='a'><div><p>a<hi>b<head>c</head>d</hi></p></div></TEI>"
+            ),
+        ]
+        for element in elements:
+            result = [self.observer.observe(node) for node in element.iter()]
+            with self.subTest():
+                self.assertEqual(sum(result), 1)
+
+    def test_observer_ignores_non_matching_elements(self):
+        elements = [
+            etree.XML("<div><head>text</head><p/></div>"),
+            etree.XML("<div><p/><p/><head><hi/></head></div>"),
+            etree.XML("<div><list><head/><item/></list></div>"),
+            etree.XML("<div><head/><ab/><p/></div>"),
+            etree.XML("<div><head>text<hi rendition='i'>b</hi></head><p/></div>"),
+            etree.XML("<div><p/><head rendition='b'>text</head>tail<ab/></div>"),
+            etree.XML("<TEI xmlsn='a'><div><head>text</head><p/></div></TEI>"),
+            etree.XML(
+                "<TEI xmlns='a'><div><list><head/><item><p/></item></list></div></TEI>"
+            ),
+            etree.XML(
+                "<TEI xmlns='A'><div><p/></div><div><head>a<hi>b</hi></head><p/></div></TEI>"
+            ),
+        ]
+        for element in elements:
+            result = {self.observer.observe(node) for node in element.iter()}
+            with self.subTest():
+                self.assertEqual(result, {False})

--- a/tests/test_use_case_impl.py
+++ b/tests/test_use_case_impl.py
@@ -1100,6 +1100,12 @@ class UseCaseTester(unittest.TestCase):
         )
         self.assertTrue(result)
 
+    def test_head_with_wrong_parent_resolved(self):
+        result = self._validate_file_processed_with_plugins(
+            "file_with_head_with_wrong_parent.xml", ["head-parent"]
+        )
+        self.assertTrue(result)
+
     def file_invalid_because_classcode_misspelled(self, file):
         logs = self._get_validation_error_logs_for_file(file)
         expected_error_msg = "Did not expect element classcode there"

--- a/tests/testdata/file_with_head_with_wrong_parent.xml
+++ b/tests/testdata/file_with_head_with_wrong_parent.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <funder>Funder</funder>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <extent>76</extent>
+      <publicationStmt>
+        <publisher>Publisher</publisher>
+        <address>
+          <addrLine>address at city</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+        <authority>
+          <name/>
+        </authority>
+      </publicationStmt>
+      <notesStmt>
+        <note type="source" anchored="true">CD</note>
+        <note type="type">
+          <idno type="date">2022-07-20</idno>
+        </note>
+      </notesStmt>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date type="first">2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="series">Series</idno>
+              <idno type="volume">1</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <editionStmt>
+            <edition>edition</edition>
+          </editionStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date>2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">Series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="bibl">bibl info</idno>
+              <idno type="series">Series</idno>
+              <idno type="page_first">11</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <bibl></bibl>
+        </taxonomy>
+      </classDecl>
+      <projectDesc default="false">
+        <p>Project</p>
+      </projectDesc>
+      <samplingDecl default="false">
+        <p>description how the file was changed</p>
+      </samplingDecl>
+    </encodingDesc>
+    <profileDesc>
+      <textClass default="false">
+        <keywords scheme="#tax">
+          <term n="1" type="main">class</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change>0</change>
+      <change when="2022-07-21"><name>Other Person</name>Change description</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+        <div>
+          <head>Title</head>
+          <p>text
+            <head>text2</head>tail1
+            <head>text3<head>text4</head>
+          </head>
+          </p>
+          <p>text5<hi>text6<head>text7</head>tail2</hi></p>
+      </div>
+      <div>
+        <p>text7
+          <head/>
+        </p>
+        <list>
+          <item>
+            <head>text</head>
+          </item>
+        </list>
+    </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
- Handle `<head/>` elements that are children  of `<p/>`, `<ab/>`, `<head/>`, `<hi/>`, or `<item/>`.