### PR TITLE
Update LinebreakDivObserver

### DIFF
--- a/tei_transform/observer/linebreak_div_observer.py
+++ b/tei_transform/observer/linebreak_div_observer.py
@@ -23,7 +23,7 @@ class LinebreakDivObserver(AbstractNodeObserver):
         if etree.QName(node).localname == "lb" and etree.QName(
             node.getparent()
         ).localname in {"div", "body"}:
-            if node.tail is not None and node.tail.strip():
+            if node.tail is not None and node.tail.strip("\n \t"):
                 return True
         return False
 

--- a/tei_transform/observer/linebreak_div_observer.py
+++ b/tei_transform/observer/linebreak_div_observer.py
@@ -1,3 +1,4 @@
+import re
 from typing import Optional
 
 from lxml import etree
@@ -28,6 +29,12 @@ class LinebreakDivObserver(AbstractNodeObserver):
         return False
 
     def transform_node(self, node: etree._Element) -> None:
+        if node.tail.strip():
+            self._handle_text_tail(node)
+        else:
+            self._handle_whitespace_tail(node)
+
+    def _handle_text_tail(self, node: etree._Element) -> None:
         prev_sibling = node.getprevious()
         if prev_sibling is None or prev_sibling != self._new_p:
             new_p = create_new_element(node, "p")
@@ -35,3 +42,6 @@ class LinebreakDivObserver(AbstractNodeObserver):
             parent.insert(parent.index(node), new_p)
             self._new_p = new_p
         self._new_p.append(node)
+
+    def _handle_whitespace_tail(self, node: etree._Element) -> None:
+        node.tail = re.sub(r"\s", " ", node.tail)

--- a/tests/test_linebreak_div_observer.py
+++ b/tests/test_linebreak_div_observer.py
@@ -44,6 +44,8 @@ class LinebreakDivObserverTester(unittest.TestCase):
             etree.XML(
                 "<TEI xmlns='a'><body><p>text<lb/>tail</p>tail<lb/>tail</body></TEI>"
             ),
+            etree.XML("<div><lb/>\n\n  \t \xa0</div>"),
+            etree.XML("<body><p/><lb/>  \u2028  </body>"),
         ]
 
         for element in elements:
@@ -72,6 +74,7 @@ class LinebreakDivObserverTester(unittest.TestCase):
             etree.XML("<body><p>text</p>tail<lb/></body>"),
             etree.XML("<TEI xmlns='a'><body><p>text<lb/>tail</p></body></TEI>"),
             etree.XML("<TEI xmlns='a'><body><p/>tail<lb/><lb/></body></TEI>"),
+            etree.XML("<div><p><lb/>  \xa0</p><p>text<lb/>\u2028</p></div>"),
         ]
         for element in elements:
             result = {self.observer.observe(node) for node in element.iter()}

--- a/tests/test_linebreak_div_observer.py
+++ b/tests/test_linebreak_div_observer.py
@@ -183,3 +183,21 @@ class LinebreakDivObserverTester(unittest.TestCase):
                 ("div", ["p"]),
             ],
         )
+
+    def test_tail_with_problematic_whitespace_cleaned(self):
+        root = etree.XML(
+            """
+        <div>
+            <lb/>   \xa0
+            <lb/>\t  \t
+            <lb/>\n\n\n
+            <lb/>  \u2028
+        </div>
+        """
+        )
+        for node in root.iter():
+            if self.observer.observe(node):
+                self.observer.transform_node(node)
+        result = [child.tail.strip(" ") for child in root]
+        self.assertEqual(["", "\t  \t\n", "\n\n\n\n", ""], result)
+        self.assertEqual(len(root), 4)

--- a/tests/testdata/file_with_linebreak_in_div.xml
+++ b/tests/testdata/file_with_linebreak_in_div.xml
@@ -131,6 +131,10 @@
             <lb/>text
           </p>
           <lb/>text
+          <lb/>  
+      
+          <lb/>
+ 
         </div>
       </div>
     </body>


### PR DESCRIPTION
- Substitue whitespace chars in all-whitespace tails with normal space to remove whitespace chars that might be treated as text.