### PR TITLE
Update double-plike plugin

### DIFF
--- a/Available_plugins.md
+++ b/Available_plugins.md
@@ -42,7 +42,7 @@ Rename ```<cell/>``` elements that are direct children of ```<cell/>``` to ```<p
 Rename ```<item/>``` elements that are direct children of  ```<item/>``` to ```<ab/>```. If the inner ```<item/>``` has children, the element will not be renamed but an additional ```<list/>``` will be inserted, wrapping the inner ```<item/>```.
 
 ### [double-plike](observer_docs/double-plike.md)
-Remove nested paragraph-like elements (`<p/>`, `<ab/>`) by stripping the inner tag.
+Remove nested paragraph-like elements (`<p/>`, `<ab/>`) by stripping the inner tag. This plugin can be configured to insert an `<lb/>` element to separate text parts of parent or older sibling and target element.
 
 ### [empty-body](observer_docs/empty-body.md)
 Add empty `<p/>` to `<body/>` element without (required) children.

--- a/observer_docs/double-plike.md
+++ b/observer_docs/double-plike.md
@@ -1,6 +1,12 @@
 ## double-plike
 Remove  `<p/>` and `<ab/>` that are children of `<p/>`-like elements (i.e. `<p/>` or `<ab/>`) by stripping the inner tag. This will add the children of the inner element as children of the parent and add text and tail of the inner element at the appropriate position. To avoid wrong concatenation of the text content, it will be padded with whitespace before concatenation and multiple whitespace characters will be stripped.
 
+This plugin can be configured to insert an `<lb/>` element between the text of the parent or the tail of the older sibling and the text content of the target element that would otherwise be concatenated to one part. To do so, include the following section in the config file:
+```
+[double-plike]
+action=add-lb
+```
+
 ### Example
 Before transformation:
 ```xml
@@ -14,8 +20,21 @@ Before transformation:
 ```
 
 After transformation:
+
+a. without configuration
 ```xml
 <div>
   <p>text1 text2<list/>tail1 tail2</p>
+</div>
+```
+
+b. with configuration
+```xml
+<div>
+  <p>text1
+    <lb/>text2
+    <list/>tail1
+    <lb/>tail2
+  </p>
 </div>
 ```

--- a/tei_transform/element_transformation.py
+++ b/tei_transform/element_transformation.py
@@ -72,12 +72,17 @@ def merge_text_content(
     return " ".join([first_part.strip(), second_part.strip()])
 
 
-def merge_into_parent(node: etree._Element) -> None:
+def merge_into_parent(node: etree._Element, add_lb=False) -> None:
     parent = node.getparent()
     last_child = node[-1] if len(node) != 0 else None
     prev_sibling = node.getprevious()
-    # avoid concatenation of text parts without whitespace
-    _pad_text_content_with_whitespace(node)
+    if add_lb and _insertion_of_lb_necessary(node, parent):
+        new_lb = create_new_element(node, "lb")
+        insert_index = parent.index(node)
+        parent.insert(insert_index, new_lb)
+    else:
+        # avoid concatenation of text parts without whitespace
+        _pad_text_content_with_whitespace(node)
     node.tag = "tempRenameToStrip"
     etree.strip_tags(parent, "tempRenameToStrip")
     _strip_multiple_whitespaces_from_text_content(parent, text=True)
@@ -102,3 +107,22 @@ def _pad_text_content_with_whitespace(node: etree._Element) -> None:
         node.text = " " + node.text
     if node.tail is not None:
         node.tail = " " + node.tail
+
+
+def _insertion_of_lb_necessary(node: etree._Element, parent: etree._Element) -> bool:
+    prev_sibling = node.getprevious()
+    if prev_sibling is not None:
+        if prev_sibling.tail is not None and prev_sibling.tail.strip():
+            if (
+                node.text is not None
+                and node.text.strip()
+                or (len(node) == 0 and node.tail is not None and node.tail.strip())
+            ):
+                return True
+        return False
+    if parent.text is not None and parent.text.strip():
+        if (node.text is not None and node.text.strip()) or (
+            len(node) == 0 and node.tail is not None and node.tail.strip()
+        ):
+            return True
+    return False

--- a/tei_transform/element_transformation.py
+++ b/tei_transform/element_transformation.py
@@ -75,14 +75,13 @@ def merge_text_content(
 def merge_into_parent(node: etree._Element, add_lb=False) -> None:
     parent = node.getparent()
     last_child = node[-1] if len(node) != 0 else None
-    prev_sibling = node.getprevious()
     if add_lb and _insertion_of_lb_necessary(node, parent):
         new_lb = create_new_element(node, "lb")
         insert_index = parent.index(node)
         parent.insert(insert_index, new_lb)
-    else:
-        # avoid concatenation of text parts without whitespace
-        _pad_text_content_with_whitespace(node)
+    prev_sibling = node.getprevious()
+    # avoid concatenation of text parts without whitespace
+    _pad_text_content_with_whitespace(node)
     node.tag = "tempRenameToStrip"
     etree.strip_tags(parent, "tempRenameToStrip")
     _strip_multiple_whitespaces_from_text_content(parent, text=True)

--- a/tei_transform/observer/double_plike_observer.py
+++ b/tei_transform/observer/double_plike_observer.py
@@ -1,7 +1,12 @@
+import logging
+from typing import Dict, Optional
+
 from lxml import etree
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
 from tei_transform.element_transformation import merge_into_parent
+
+logger = logging.getLogger(__name__)
 
 
 class DoublePlikeObserver(AbstractNodeObserver):
@@ -13,6 +18,9 @@ class DoublePlikeObserver(AbstractNodeObserver):
     of the inner element will be preserved).
     """
 
+    def __init__(self, action: Optional[str] = None) -> None:
+        self.action = action
+
     def observe(self, node: etree._Element) -> bool:
         p_like_tags = {"p", "ab"}
         if etree.QName(node).localname in p_like_tags:
@@ -23,3 +31,10 @@ class DoublePlikeObserver(AbstractNodeObserver):
 
     def transform_node(self, node: etree._Element) -> None:
         merge_into_parent(node)
+
+    def configure(self, config_dict: Dict[str, str]) -> None:
+        action = config_dict.get("action", None)
+        if action is not None:
+            self.action = action
+        else:
+            logger.warning("Invalid configuration, using default.")

--- a/tei_transform/observer/double_plike_observer.py
+++ b/tei_transform/observer/double_plike_observer.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional
 from lxml import etree
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
-from tei_transform.element_transformation import create_new_element, merge_into_parent
+from tei_transform.element_transformation import merge_into_parent
 
 logger = logging.getLogger(__name__)
 
@@ -30,9 +30,10 @@ class DoublePlikeObserver(AbstractNodeObserver):
         return False
 
     def transform_node(self, node: etree._Element) -> None:
+        add_lb = False
         if self.action == "add-lb":
-            self._add_linebreak_to_separate_text_parts(node)
-        merge_into_parent(node)
+            add_lb = True
+        merge_into_parent(node, add_lb=add_lb)
 
     def configure(self, config_dict: Dict[str, str]) -> None:
         action = config_dict.get("action", None)
@@ -40,15 +41,3 @@ class DoublePlikeObserver(AbstractNodeObserver):
             self.action = action
         else:
             logger.warning("Invalid configuration, using default.")
-
-    def _add_linebreak_to_separate_text_parts(self, node: etree._Element) -> None:
-        parent = node.getparent()
-        if (parent.text is not None and parent.text.strip()) and (
-            node.text is not None
-            and node.text.strip()
-            or (node.tail is not None and node.tail.strip() and len(node) == 0)
-        ):
-            pass
-            new_lb = create_new_element(node, "lb")
-            insert_index = parent.index(node)
-            parent.insert(insert_index, new_lb)

--- a/tei_transform/observer/double_plike_observer.py
+++ b/tei_transform/observer/double_plike_observer.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional
 from lxml import etree
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
-from tei_transform.element_transformation import merge_into_parent
+from tei_transform.element_transformation import create_new_element, merge_into_parent
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +30,8 @@ class DoublePlikeObserver(AbstractNodeObserver):
         return False
 
     def transform_node(self, node: etree._Element) -> None:
+        if self.action == "add-lb":
+            self._add_linebreak_to_separate_text_parts(node)
         merge_into_parent(node)
 
     def configure(self, config_dict: Dict[str, str]) -> None:
@@ -38,3 +40,15 @@ class DoublePlikeObserver(AbstractNodeObserver):
             self.action = action
         else:
             logger.warning("Invalid configuration, using default.")
+
+    def _add_linebreak_to_separate_text_parts(self, node: etree._Element) -> None:
+        parent = node.getparent()
+        if (parent.text is not None and parent.text.strip()) and (
+            node.text is not None
+            and node.text.strip()
+            or (node.tail is not None and node.tail.strip() and len(node) == 0)
+        ):
+            pass
+            new_lb = create_new_element(node, "lb")
+            insert_index = parent.index(node)
+            parent.insert(insert_index, new_lb)

--- a/tei_transform/observer/double_plike_observer.py
+++ b/tei_transform/observer/double_plike_observer.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional
+from typing import Dict
 
 from lxml import etree
 
@@ -20,8 +20,8 @@ class DoublePlikeObserver(AbstractNodeObserver):
     separate text parts of target and parent resp. older sibling.
     """
 
-    def __init__(self, action: Optional[str] = None) -> None:
-        self.action = action
+    def __init__(self, add_lb: bool = False) -> None:
+        self._add_lb = add_lb
 
     def observe(self, node: etree._Element) -> bool:
         p_like_tags = {"p", "ab"}
@@ -32,14 +32,11 @@ class DoublePlikeObserver(AbstractNodeObserver):
         return False
 
     def transform_node(self, node: etree._Element) -> None:
-        add_lb = False
-        if self.action == "add-lb":
-            add_lb = True
-        merge_into_parent(node, add_lb=add_lb)
+        merge_into_parent(node, add_lb=self._add_lb)
 
     def configure(self, config_dict: Dict[str, str]) -> None:
         action = config_dict.get("action", None)
-        if action is not None:
-            self.action = action
+        if action is not None and action == "add-lb":
+            self._add_lb = True
         else:
             logger.warning("Invalid configuration, using default.")

--- a/tei_transform/observer/double_plike_observer.py
+++ b/tei_transform/observer/double_plike_observer.py
@@ -16,6 +16,8 @@ class DoublePlikeObserver(AbstractNodeObserver):
     Find <p/> and <ab/> elements that have <p/> or <ab/> as parent
     and strip the inner tag (text and tail as well as the children
     of the inner element will be preserved).
+    This observer can be configured to insert an <lb/> element to
+    separate text parts of target and parent resp. older sibling.
     """
 
     def __init__(self, action: Optional[str] = None) -> None:

--- a/tei_transform/observer/head_child_observer.py
+++ b/tei_transform/observer/head_child_observer.py
@@ -1,7 +1,7 @@
 from lxml import etree
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
-from tei_transform.element_transformation import create_new_element, merge_into_parent
+from tei_transform.element_transformation import merge_into_parent
 
 
 class HeadChildObserver(AbstractNodeObserver):
@@ -23,12 +23,4 @@ class HeadChildObserver(AbstractNodeObserver):
         return False
 
     def transform_node(self, node: etree._Element) -> None:
-        parent = node.getparent()
-        if (parent.text is not None and parent.text.strip()) and (
-            (node.text is not None and node.text.strip())
-            or (node.tail is not None and node.tail.strip() and len(node) == 0)
-        ):
-            new_lb = create_new_element(node, "lb")
-            insert_index = parent.index(node)
-            parent.insert(insert_index, new_lb)
-        merge_into_parent(node)
+        merge_into_parent(node, add_lb=True)

--- a/tei_transform/observer/hi_child_observer.py
+++ b/tei_transform/observer/hi_child_observer.py
@@ -1,7 +1,7 @@
 from lxml import etree
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
-from tei_transform.element_transformation import create_new_element, merge_into_parent
+from tei_transform.element_transformation import merge_into_parent
 
 
 class HiChildObserver(AbstractNodeObserver):
@@ -27,16 +27,4 @@ class HiChildObserver(AbstractNodeObserver):
         return False
 
     def transform_node(self, node: etree._Element) -> None:
-        parent = node.getparent()
-        if (
-            parent.text is not None
-            and parent.text.strip()
-            and (
-                (node.text is not None and node.text.strip())
-                or (node.tail is not None and node.tail.strip() and len(node) == 0)
-            )
-        ):
-            new_lb = create_new_element(node, "lb")
-            insert_index = parent.index(node)
-            parent.insert(insert_index, new_lb)
-        merge_into_parent(node)
+        merge_into_parent(node, add_lb=True)

--- a/tests/test_double_plike_observer.py
+++ b/tests/test_double_plike_observer.py
@@ -318,24 +318,26 @@ class DoublePlikeObserverTester(unittest.TestCase):
     def test_configure_observer(self):
         config = {"action": "add-lb"}
         self.observer.configure(config)
-        self.assertEqual(self.observer.action, "add-lb")
+        self.assertTrue(self.observer._add_lb)
 
     def test_observer_not_configured_if_config_wrong(self):
         config = {"do_sth": "add.lb"}
         self.observer.configure(config)
-        self.assertIsNone(self.observer.action)
+        self.assertEqual(self.observer._add_lb, False)
 
     def test_invalid_config_triggers_log_warning(self):
-        config = {"do_sth": "add.lb"}
-        with self.assertLogs() as logger:
-            self.observer.configure(config)
-        self.assertEqual(
-            logger.output,
-            [
-                "WARNING:tei_transform.observer.double_plike_observer:"
-                "Invalid configuration, using default."
-            ],
-        )
+        configs = [{"do_sth": "add.lb"}, {"action": "do-sth"}]
+        for config in configs:
+            with self.subTest():
+                with self.assertLogs() as logger:
+                    self.observer.configure(config)
+                    self.assertEqual(
+                        logger.output,
+                        [
+                            "WARNING:tei_transform.observer.double_plike_observer:"
+                            "Invalid configuration, using default."
+                        ],
+                    )
 
     def test_lb_added_to_separate_text_parts_if_configured(self):
         self.observer.configure(self.valid_cfg)

--- a/tests/test_double_plike_observer.py
+++ b/tests/test_double_plike_observer.py
@@ -8,6 +8,7 @@ from tei_transform.observer import DoublePlikeObserver
 class DoublePlikeObserverTester(unittest.TestCase):
     def setUp(self):
         self.observer = DoublePlikeObserver()
+        self.valid_cfg = {"action": "add-lb"}
 
     def test_observer_returns_true_for_matching_element(self):
         root = etree.XML("<div><p><p>text</p></p></div>")
@@ -313,3 +314,25 @@ class DoublePlikeObserverTester(unittest.TestCase):
         node = root.find(".//p")
         self.observer.transform_node(node)
         self.assertEqual(root.find(".//list").tail, "text")
+
+    def test_configure_observer(self):
+        config = {"action": "add-lb"}
+        self.observer.configure(config)
+        self.assertEqual(self.observer.action, "add-lb")
+
+    def test_observer_not_configured_if_config_wrong(self):
+        config = {"do_sth": "add.lb"}
+        self.observer.configure(config)
+        self.assertIsNone(self.observer.action)
+
+    def test_invalid_config_triggers_log_warning(self):
+        config = {"do_sth": "add.lb"}
+        with self.assertLogs() as logger:
+            self.observer.configure(config)
+        self.assertEqual(
+            logger.output,
+            [
+                "WARNING:tei_transform.observer.double_plike_observer:"
+                "Invalid configuration, using default."
+            ],
+        )

--- a/tests/test_element_transformation.py
+++ b/tests/test_element_transformation.py
@@ -695,3 +695,49 @@ def test_lb_added_parent_with_text_and_child_with_tail_target_text():
     target = xml.find(".//inner")
     et.merge_into_parent(target, add_lb=True)
     assert xml.find(".//lb").tail.strip() == "text2"
+
+
+def test_text_and_tail_of_node_separated_by_whitespace_if_lb_added():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>text1
+                <inner>text2</inner>tail
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb").tail == "text2 tail"
+
+
+def test_text_and_tail_of_target_separated_by_whitespace_if_lb_adding_not_necessary():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>text1
+                <sibling/>
+                <inner>text2</inner>tail
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//sibling").tail == "text2 tail"
+
+
+def test_formatting_whitespace_on_lb_removed_after_merge():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>text1
+                <inner/>tail
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb").tail == "tail"

--- a/tests/test_element_transformation.py
+++ b/tests/test_element_transformation.py
@@ -476,3 +476,222 @@ def test_merge_into_parent_formatting_whitespace_removed_text_and_tail():
     target = xml.find(".//inner")
     et.merge_into_parent(target)
     assert "text text2 tail" in xml[0].text
+
+
+def test_merge_lb_added_parent_text_target_text():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>text
+                <inner>text2</inner>
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb").tail.strip() == "text2"
+
+
+def test_merge_lb_added_parent_text_target_only_tail():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>text
+                <inner/>text2
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb").tail.strip() == "text2"
+
+
+def test_merge_no_lb_added_parent_text_target_with_child():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>text
+                <inner><child>text2</child></inner>tail
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb") is None
+
+
+def test_merge_lb_added_parent_text_target_text_and_child():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>text
+                <inner>target<child>text2</child></inner>tail
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb").tail.strip() == "target"
+
+
+def test_merge_no_lb_added_parent_no_text_target_text():
+    xml = etree.XML(
+        """
+        <div>
+            <outer><inner>text2</inner>tail
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb") is None
+
+
+def test_merge_no_lb_added_parent_only_whitespace_text_target_text():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>\n\n\t
+                <inner>text2</inner>tail
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb") is None
+
+
+def test_merge_no_lb_added_parent_no_text_target_tail():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>
+                <inner/>tail
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb") is None
+
+
+def test_no_lb_added_parent_no_text_target_with_child():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>
+                <inner>
+                    <child>text</child>
+                </inner>
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb") is None
+
+
+def test_merge_lb_added_older_sibling_with_tail_target_text():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>
+                <sibling/>tail
+                <inner>text</inner>
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb").tail.strip() == "text"
+
+
+def test_merge_no_lb_added_older_sibling_no_tail_target_text():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>
+                <sibling/>
+                <inner>text</inner>
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb") is None
+
+
+def test_merge_lb_added_older_sibling_tail_target_tail():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>
+                <sibling/>tail
+                <inner/>text
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb").tail.strip() == "text"
+
+
+def test_merge_no_lb_added_older_sibling_with_tail_target_only_with_child():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>
+                <sibling/>tail
+                <inner>
+                    <child>text</child>
+                </inner>
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb") is None
+
+
+def test_merge_no_lb_added_parent_with_text_and_child_target_with_text():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>text1
+                <sibling/>
+                <inner>text2</inner>
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb") is None
+
+
+def test_lb_added_parent_with_text_and_child_with_tail_target_text():
+    xml = etree.XML(
+        """
+        <div>
+            <outer>text1
+                <sibling/>tail
+                <inner>text2</inner>
+            </outer>
+        </div>
+        """
+    )
+    target = xml.find(".//inner")
+    et.merge_into_parent(target, add_lb=True)
+    assert xml.find(".//lb").tail.strip() == "text2"

--- a/tests/test_use_case_impl.py
+++ b/tests/test_use_case_impl.py
@@ -1150,6 +1150,17 @@ class UseCaseTester(unittest.TestCase):
         )
         self.assertTrue(result)
 
+    def test_configured_double_p_like_plugin(self):
+        cfg = os.path.join(self.data, "conf_files", "db-p.cfg")
+        file = os.path.join(
+            self.data,
+            "file_with_nested_p_like.xml",
+        )
+        request = CliRequest(file, ["double-plike"], config=cfg)
+        self.use_case.process(request)
+        _, output = self.xml_writer.assertSingleDocumentWritten()
+        self.assertEqual(len(output.findall(".//{*}lb")), 3)
+
     def file_invalid_because_classcode_misspelled(self, file):
         logs = self._get_validation_error_logs_for_file(file)
         expected_error_msg = "Did not expect element classcode there"

--- a/tests/testdata/conf_files/db-p.cfg
+++ b/tests/testdata/conf_files/db-p.cfg
@@ -1,0 +1,2 @@
+[double-plike]
+action=add-lb


### PR DESCRIPTION
- Add optional configuration to *double-plike* plugin that allows insertion of `<lb/>` between text parts to avoid concatenation of text/tail of older sibling and text content of target element.
- Simplify code of `HeadChildObserver` and `HiChildObserver` by using the new option.