### PR TITLE
Handle deprecation warning for importlib

### DIFF
--- a/tei_transform/observer_constructor.py
+++ b/tei_transform/observer_constructor.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import configparser
+import sys
 from importlib import metadata
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
 
@@ -12,8 +15,18 @@ class ObserverConstructor:
     """
 
     def __init__(self) -> None:
-        self.entry_points = metadata.entry_points()["node_observer"]
+        self.entry_points = self._get_node_observer_entry_points()
         self.plugins_by_name = {plugin.name: plugin for plugin in self.entry_points}
+
+    @classmethod
+    def _get_node_observer_entry_points(
+        cls,
+    ) -> Union[Tuple[metadata.EntryPoint], metadata.EntryPoints]:
+        if sys.version_info < (3, 10):
+            entry_points = metadata.entry_points()["node_observer"]
+        else:
+            entry_points = metadata.entry_points().select(group="node_observer")
+        return entry_points
 
     def construct_observers(
         self,

--- a/tests/mock_observer.py
+++ b/tests/mock_observer.py
@@ -1,3 +1,4 @@
+import sys
 from importlib import metadata
 
 from lxml import etree
@@ -42,5 +43,4 @@ def add_mock_plugin_entry_point(observer_constructor, plugin_name, plugin_path):
         value=plugin_path,
         group="node_observer",
     )
-    observer_constructor.entry_points += mock_entry_point
     observer_constructor.plugins_by_name[plugin_name] = mock_entry_point

--- a/tests/mock_observer.py
+++ b/tests/mock_observer.py
@@ -1,4 +1,3 @@
-import sys
 from importlib import metadata
 
 from lxml import etree


### PR DESCRIPTION
`dict` interface of `EntryPoint` is deprecated since Python3.10, in favor of new interface class `EntryPoints` 