### PR TITLE
Fix list-text plugin

### DIFF
--- a/observer_docs/list-text.md
+++ b/observer_docs/list-text.md
@@ -1,7 +1,7 @@
 ## list-text
 Remove text from ```<list/>``` elements and add under new ```<item/>```.
 
-Find ```<list/>``` elements that contain text or any elements with tail. The text content of `<list/>` is added under a new ```<item/>``` element. Any text content in tails on `<item/>` or other children of the `<list/>` are concatenated with the text content of the `<item/>` (resp. added to the tail of the last child if `<item/>`, if present). If the child has `<lb/>` tag, it is appended to its previous sibling.
+Find ```<list/>``` elements that contain text or any elements with tail. The text content of `<list/>` is added under a new ```<item/>``` element. Any text content in tails on `<item/>` or other (valid) children of the `<list/>` are concatenated with the text content of the `<item/>` (resp. added to the tail of the last child if `<item/>`, if present). If the child has `<lb/>` tag, it is appended to its previous sibling. If the `<lb/>` has no previous sibling, its tag is converted to `<item/>`.
 
 ### Example
 Before transformation:

--- a/tei_transform/observer/list_text_observer.py
+++ b/tei_transform/observer/list_text_observer.py
@@ -36,8 +36,8 @@ class ListTextObserver(AbstractNodeObserver):
             self._remove_text_content_from_list(node)
         for child in node.iterchildren():
             if child.tail is not None and child.tail.strip():
-                if etree.QName(child).localname == "item":
-                    self._remove_tail_from_item_child(child)
+                if etree.QName(child).localname in {"item", "head", "fw"}:
+                    self._remove_tail_from_valid_child(child)
                 if etree.QName(child).localname == "lb":
                     self._handle_lb_child(node, child)
 
@@ -47,13 +47,13 @@ class ListTextObserver(AbstractNodeObserver):
         node.text = None
         node.insert(0, new_item)
 
-    def _remove_tail_from_item_child(self, item_child: etree._Element) -> None:
-        if len(item_child) != 0:
-            last_subchild = item_child[0]
-            last_subchild.tail = merge_text_content(last_subchild.tail, item_child.tail)
+    def _remove_tail_from_valid_child(self, child: etree._Element) -> None:
+        if len(child) != 0:
+            last_subchild = child[0]
+            last_subchild.tail = merge_text_content(last_subchild.tail, child.tail)
         else:
-            item_child.text = merge_text_content(item_child.text, item_child.tail)
-        item_child.tail = None
+            child.text = merge_text_content(child.text, child.tail)
+        child.tail = None
 
     def _handle_lb_child(self, node: etree._Element, lb_child: etree._Element) -> None:
         prev_sibling = lb_child.getprevious()

--- a/tei_transform/observer/list_text_observer.py
+++ b/tei_transform/observer/list_text_observer.py
@@ -13,11 +13,12 @@ class ListTextObserver(AbstractNodeObserver):
     Observer for <list/> elements that contain text.
 
     Find <list/> elements that contain text and add the text
-    under a new <item/> element or have any <item/> elements
-    with tail as children and concatenate the tail with the
-    text content of the <item/>.
-    If the <list/> contains <lb/> elements, the <lb/> is
-    appended to its previous sibling.
+    under a new <item/> element or have any <item/>, <head/>, or
+    <fw/> elements with tail as children and concatenate the
+    tail with the text content of the child element.
+    If the <list/> contains <lb/> elements with tail, the <lb/>
+    is appended to its previous sibling, resp. converted to <item/>
+    if it has no previous siblings.
     """
 
     def observe(self, node: etree._Element) -> bool:

--- a/tei_transform/observer/list_text_observer.py
+++ b/tei_transform/observer/list_text_observer.py
@@ -35,14 +35,11 @@ class ListTextObserver(AbstractNodeObserver):
         if node.text is not None and node.text.strip():
             self._remove_text_content_from_list(node)
         for child in node.iterchildren():
-            if (
-                etree.QName(child).localname == "item"
-                and child.tail is not None
-                and child.tail.strip()
-            ):
-                self._remove_tail_from_item_child(child)
-            if etree.QName(child).localname == "lb":
-                self._handle_lb_child(node, child)
+            if child.tail is not None and child.tail.strip():
+                if etree.QName(child).localname == "item":
+                    self._remove_tail_from_item_child(child)
+                if etree.QName(child).localname == "lb":
+                    self._handle_lb_child(node, child)
 
     def _remove_text_content_from_list(self, node: etree._Element) -> None:
         new_item = create_new_element(node, "item")

--- a/tei_transform/observer/list_text_observer.py
+++ b/tei_transform/observer/list_text_observer.py
@@ -40,7 +40,7 @@ class ListTextObserver(AbstractNodeObserver):
                 if etree.QName(child).localname in {"item", "head", "fw"}:
                     self._remove_tail_from_valid_child(child)
                 if etree.QName(child).localname == "lb":
-                    self._handle_lb_child(node, child)
+                    self._handle_lb_child(child)
 
     def _remove_text_content_from_list(self, node: etree._Element) -> None:
         new_item = create_new_element(node, "item")
@@ -56,7 +56,7 @@ class ListTextObserver(AbstractNodeObserver):
             child.text = merge_text_content(child.text, child.tail)
         child.tail = None
 
-    def _handle_lb_child(self, node: etree._Element, lb_child: etree._Element) -> None:
+    def _handle_lb_child(self, lb_child: etree._Element) -> None:
         prev_sibling = lb_child.getprevious()
         if prev_sibling is None:
             change_element_tag(lb_child, "item")

--- a/tests/test_list_text_observer.py
+++ b/tests/test_list_text_observer.py
@@ -525,3 +525,26 @@ class ListTextObserverTester(unittest.TestCase):
         node = root[0]
         self.observer.transform_node(node)
         self.assertTrue(root.find(".//list/lb") is not None)
+
+    def test_tail_only_on_valid_children_removed(self):
+        root = etree.XML(
+            """
+            <div>
+                <list>
+                    <head>text</head>tail
+                    <item/>tail
+                    <p>text1</p>tail1
+                    <fw>text2</fw>tail2
+                    <item>text3</item>tail3
+                </list>
+            </div>
+            """
+        )
+        node = root[0]
+        self.observer.transform_node(node)
+        result = [
+            (child.tag, child.tail.strip())
+            for child in node
+            if child.tail is not None and child.tail.strip()
+        ]
+        self.assertEqual(result, [("p", "tail1")])

--- a/tests/test_list_text_observer.py
+++ b/tests/test_list_text_observer.py
@@ -519,3 +519,9 @@ class ListTextObserverTester(unittest.TestCase):
         node = root[0]
         self.observer.transform_node(node)
         self.assertEqual(node[0].text, "tail")
+
+    def test_lb_without_tail_not_converted_to_item(self):
+        root = etree.XML("<div><list><item/><lb/><item/></list></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertTrue(root.find(".//list/lb") is not None)


### PR DESCRIPTION
- Changed handling of `<lb/>` without tail
- Extended tail removal of children by more valid children of `<list/>` ( `<fw/>` and `<head/>`) 