### PR TITLE
Add h-level plugin

### DIFF
--- a/Available_plugins.md
+++ b/Available_plugins.md
@@ -68,6 +68,9 @@ Remove ```<filename/>``` elements.
 ### [fw-child](observer_docs/fw-child.md)
 Find `<p/>`, `<list/>`, and `<table/>` elements with `<fw/>` parent. Merge `<p/>` element into parent. Rename parent to `<ab/>` if target has tag `<list/>` or `<table/>`.
 
+### [h-level](observer_docs/h-level.md)
+Change tag of elements with `h#` tag (e.g. `<h2/>`) to `<ab/>`.
+
 ### [head-child](observer_docs/head-child.md)
 Remove `<p/>` and `<ab/>` elements with `<head/>` parent by stripping the inner tag.
 

--- a/observer_docs/h-level.md
+++ b/observer_docs/h-level.md
@@ -1,0 +1,27 @@
+## h-level
+Change tag of elements with 'h#' tag (e.g. `<h3/>`) to `<ab/>` and add `@type='head'` attribute and `@rend` with the old tag name as value. Invalid attributes, such as `@class` and `@title` are removed from the element.
+
+### Example
+Before transformation:
+```xml
+<div>
+  <head/>
+  <p/>
+  <h3 class='sth'>
+    <lb/>text
+  </h3>
+  <p/>
+</div>
+```
+
+After transformation:
+```xml
+<div>
+  <head/>
+  <p/>
+  <ab type="head" rend="h3">
+    <lb/>text
+  </ab>
+  <p/>
+</div>
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ empty-scheme = "tei_transform.observer.scheme_attribute_observer:SchemeAttribute
 empty-stmt = "tei_transform.observer.empty_stmt_observer:EmptyStmtObserver"
 filename-element = "tei_transform.observer.filename_element_observer:FilenameElementObserver"
 fw-child = "tei_transform.observer.fw_child_observer:FwChildObserver"
+h-level = "tei_transform.observer.h_level_observer:HLevelObserver"
 head-child = "tei_transform.observer.head_child_observer:HeadChildObserver"
 head-parent = "tei_transform.observer.head_parent_observer:HeadParentObserver"
 head-type = "tei_transform.observer.head_with_type_attr_observer:HeadWithTypeAttrObserver"

--- a/tei_transform/observer/__init__.py
+++ b/tei_transform/observer/__init__.py
@@ -22,6 +22,7 @@ from tei_transform.observer.empty_p_publicationstmt_observer import (
 from tei_transform.observer.empty_stmt_observer import EmptyStmtObserver
 from tei_transform.observer.filename_element_observer import FilenameElementObserver
 from tei_transform.observer.fw_child_observer import FwChildObserver
+from tei_transform.observer.h_level_observer import HLevelObserver
 from tei_transform.observer.head_after_p_element_observer import (
     HeadAfterPElementObserver,
 )

--- a/tei_transform/observer/h_level_observer.py
+++ b/tei_transform/observer/h_level_observer.py
@@ -1,11 +1,19 @@
 from lxml import etree
 
 from tei_transform.abstract_node_observer import AbstractNodeObserver
+from tei_transform.element_transformation import (
+    change_element_tag,
+    remove_attribute_from_node,
+)
 
 
 class HLevelObserver(AbstractNodeObserver):
     """
     Observer for <h#/> elements.
+
+    Change tag of elements with 'h#' tag (e.g. 'h2') to 'ab' and add
+    @type='head' and @rend with the old tag name as value.
+    Invalid attributes, such as @class and @title, are removed.
     """
 
     def observe(self, node: etree._Element) -> bool:
@@ -15,4 +23,10 @@ class HLevelObserver(AbstractNodeObserver):
         return False
 
     def transform_node(self, node: etree._Element) -> None:
-        pass
+        old_tag = etree.QName(node).localname
+        change_element_tag(node, "ab")
+        node.set("type", "head")
+        node.set("rend", old_tag)
+        unwanted_attributes = ["class", "title"]
+        for attr in unwanted_attributes:
+            remove_attribute_from_node(node, attr)

--- a/tei_transform/observer/h_level_observer.py
+++ b/tei_transform/observer/h_level_observer.py
@@ -1,0 +1,18 @@
+from lxml import etree
+
+from tei_transform.abstract_node_observer import AbstractNodeObserver
+
+
+class HLevelObserver(AbstractNodeObserver):
+    """
+    Observer for <h#/> elements.
+    """
+
+    def observe(self, node: etree._Element) -> bool:
+        if len(tag := etree.QName(node).localname) == 2:
+            if tag.startswith("h") and tag[1].isnumeric():
+                return True
+        return False
+
+    def transform_node(self, node: etree._Element) -> None:
+        pass

--- a/tests/test_h_level_observer.py
+++ b/tests/test_h_level_observer.py
@@ -63,3 +63,71 @@ class HLevelObserverTester(unittest.TestCase):
             result = {self.observer.observe(node) for node in element.iter()}
             with self.subTest():
                 self.assertEqual(result, {False})
+
+    def test_tag_changed_to_ab(self):
+        root = etree.XML("<div><h3>text</h3></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertEqual(node.tag, "ab")
+
+    def test_tag_changed_to_ab_with_namespace(self):
+        root = etree.XML(
+            "<TEI xmlns='http://www.tei-c.org/ns/1.0'><div><h4>text</h4></div></TEI>"
+        )
+        node = root.find(".//{*}h4")
+        self.observer.transform_node(node)
+        self.assertEqual(etree.QName(node).localname, "ab")
+        self.assertEqual(etree.QName(node).namespace, "http://www.tei-c.org/ns/1.0")
+
+    def test_type_attribute_added(self):
+        root = etree.XML("<div><h2>text</h2><p/></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertEqual(node.attrib.get("type"), "head")
+
+    def test_rend_attribute_added_with_old_tag_name(self):
+        for i in range(2, 9):
+            tag_name = f"h{i}"
+            root = etree.XML(f"<div><{tag_name}>text</{tag_name}></div>")
+            node = root[0]
+            self.observer.transform_node(node)
+            with self.subTest():
+                self.assertEqual(node.attrib.get("rend"), tag_name)
+
+    def test_rend_attribute_added_with_old_tag_name_with_namespace(self):
+        for i in range(2, 9):
+            tag_name = f"h{i}"
+            root = etree.XML(
+                f"<TEI xmlns='http://www.tei-c.org/ns/1.0'><div><p/><{tag_name}>text</{tag_name}></div></TEI>"
+            )
+            node = root.find(".//{*}div")[1]
+            self.observer.transform_node(node)
+            with self.subTest():
+                self.assertEqual(node.attrib.get("rend"), tag_name)
+
+    def test_unwanted_attributes_removed(self):
+        root = etree.XML("<div><h2 class='sth' title='a'>text</h2></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertEqual(node.attrib, {"type": "head", "rend": "h2"})
+
+    def test_other_attributes_not_removed(self):
+        root = etree.XML("<div><h4 xml:id='sth' class='a' n='a' rendition='#i'/></div>")
+        node = root[0]
+        self.observer.transform_node(node)
+        self.assertEqual(
+            (node.attrib),
+            {
+                "{http://www.w3.org/XML/1998/namespace}id": "sth",
+                "n": "a",
+                "rendition": "#i",
+                "rend": "h4",
+                "type": "head",
+            },
+        )
+
+    def test_element_with_children_renamed(self):
+        root = etree.XML("<div><p/><h3><lb/>text</h3><p/></div>")
+        node = root.find("h3")
+        self.observer.transform_node(node)
+        self.assertEqual(len(node), 1)

--- a/tests/test_h_level_observer.py
+++ b/tests/test_h_level_observer.py
@@ -1,0 +1,65 @@
+import unittest
+
+from lxml import etree
+
+from tei_transform.observer import HLevelObserver
+
+
+class HLevelObserverTester(unittest.TestCase):
+    def setUp(self):
+        self.observer = HLevelObserver()
+
+    def test_observer_returns_true_for_matching_element(self):
+        root = etree.XML("<div><p/><h2>text</h2></div>")
+        node = root[1]
+        result = self.observer.observe(node)
+        self.assertTrue(result)
+
+    def test_observer_returns_false_for_non_matching_element(self):
+        root = etree.XML("<div><hi/></div>")
+        node = root[0]
+        result = self.observer.observe(node)
+        self.assertEqual(result, False)
+
+    def test_observer_identifies_matching_elements(self):
+        elements = [
+            etree.XML("<div><h3><lb/>text</h3></div>"),
+            etree.XML("<div><p/><h4>text</h4><p/></div>"),
+            etree.XML("<div><p/><h5 class='sth'><lb/></h5></div>"),
+            etree.XML("<div><h6 title='sth'><lb/>text</h6><p/></div>"),
+            etree.XML("<body><div><p/><h7>text</h7></div></body>"),
+            etree.XML("<div><h8/><p/></div>"),
+            etree.XML("<TEI xlmns='a'><body><div><h2>ab</h2><p/></div></body></TEI>"),
+            etree.XML(
+                "<TEI xlmns='a'><body><div><h3 class='sth'><lb/>ab</h3><p/></div></body></TEI>"
+            ),
+            etree.XML(
+                "<TEI xlmns='a'><body><div><p/><h4>ab</h4><p/></div></body></TEI>"
+            ),
+            etree.XML(
+                "<TEI xlmns='a'><body><div><p/><h5><lb/></h5><p/></div></body></TEI>"
+            ),
+        ]
+        for element in elements:
+            result = [self.observer.observe(node) for node in element.iter()]
+            with self.subTest():
+                self.assertEqual(sum(result), 1)
+
+    def test_observer_ignores_non_matching_elements(self):
+        elements = [
+            etree.XML("<div><p><hi/></p></div>"),
+            etree.XML("<div><p/><hi/><p/></div>"),
+            etree.XML("<div><head>txt</head><p>ab</p></div>"),
+            etree.XML("<div><hi/><p/></div>"),
+            etree.XML(
+                "<TEI xlmns='a'><body><div><head>ab</head><p/></div></body></TEI>"
+            ),
+            etree.XML("<TEI xlmns='a'><body><div><hi>ab</hi><p/></div></body></TEI>"),
+            etree.XML(
+                "<TEI xlmns='a'><body><div><p><hi>ab</hi></p><p/></div></body></TEI>"
+            ),
+        ]
+        for element in elements:
+            result = {self.observer.observe(node) for node in element.iter()}
+            with self.subTest():
+                self.assertEqual(result, {False})

--- a/tests/test_use_case_impl.py
+++ b/tests/test_use_case_impl.py
@@ -1319,6 +1319,12 @@ class UseCaseTester(unittest.TestCase):
         )
         self.assertTrue(result)
 
+    def test_h_level_resolved(self):
+        result = self._validate_file_processed_with_plugins(
+            "file_with_numbered_h_elements.xml", ["h-level"]
+        )
+        self.assertTrue(result)
+
     def file_invalid_because_classcode_misspelled(self, file):
         logs = self._get_validation_error_logs_for_file(file)
         expected_error_msg = "Did not expect element classcode there"

--- a/tests/testdata/file_with_numbered_h_elements.xml
+++ b/tests/testdata/file_with_numbered_h_elements.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <funder>Funder</funder>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <extent>76</extent>
+      <publicationStmt>
+        <publisher>Publisher</publisher>
+        <address>
+          <addrLine>address at city</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+        <authority>
+          <name/>
+        </authority>
+      </publicationStmt>
+      <notesStmt>
+        <note type="source" anchored="true">CD</note>
+        <note type="type">
+          <idno type="date">2022-07-20</idno>
+        </note>
+      </notesStmt>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date type="first">2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="series">Series</idno>
+              <idno type="volume">1</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+      <sourceDesc>
+        <bibl default="false">bibl info</bibl>
+        <biblFull default="false">
+          <titleStmt>
+            <title level="a" type="main">Title</title>
+            <author/>
+          </titleStmt>
+          <editionStmt>
+            <edition>edition</edition>
+          </editionStmt>
+          <publicationStmt>
+            <publisher>Publisher</publisher>
+            <pubPlace>Some city</pubPlace>
+            <date>2022-07-20</date>
+          </publicationStmt>
+          <seriesStmt>
+            <title level="j">Series</title>
+            <idno type="volume">1</idno>
+            <idno type="page">11</idno>
+          </seriesStmt>
+          <notesStmt>
+            <note type="bibl">
+              <idno type="bibl">bibl info</idno>
+              <idno type="series">Series</idno>
+              <idno type="page_first">11</idno>
+            </note>
+          </notesStmt>
+        </biblFull>
+      </sourceDesc>
+    </fileDesc>
+    <encodingDesc>
+      <classDecl>
+        <taxonomy>
+          <bibl></bibl>
+        </taxonomy>
+      </classDecl>
+      <projectDesc default="false">
+        <p>Project</p>
+      </projectDesc>
+      <samplingDecl default="false">
+        <p>description how the file was changed</p>
+      </samplingDecl>
+    </encodingDesc>
+    <profileDesc>
+      <textClass default="false">
+        <keywords scheme="#tax">
+          <term n="1" type="main">class</term>
+        </keywords>
+      </textClass>
+    </profileDesc>
+    <revisionDesc>
+      <change>0</change>
+      <change when="2022-07-21"><name>Other Person</name>Change description</change>
+    </revisionDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <div>
+        <head>Title</head>
+        <p>text</p>
+        <h2 class='sth' title='sth'>
+          <lb/>text
+        </h2>
+        <p>text</p>
+        <h3 class='sth'>text</h3>
+        <p>text</p>
+        <h4 class='sth'>text</h4>
+        <p>text</p>
+        <h5 rendition='#i'>text</h5>
+        <p>text</p>
+        <h6 n='sth'>text</h6>
+        <p>text</p>
+        <h7 class='sth'>text</h7>
+        <p>text</p>
+        <h8 class='sth'>text</h8>
+        <p>text</p>
+    </div>
+    </body>
+  </text>
+</TEI>


### PR DESCRIPTION
- Added *h-level* plugin to change tag of elements from `h#,` e.g. `<h2/>` to `<ab/>`